### PR TITLE
Issue model refactoring

### DIFF
--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -56,9 +56,8 @@ const issueSchema = new Schema({
   },
 });
 
-issueSchema.statics.build = (issue: IssueType): IssueDocument => {
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  return new Issue(issue);
+issueSchema.statics.build = function buildIssue(issue: IssueType): IssueDocument {
+  return new this(issue);
 };
 
 const Issue = model<IssueDocument, IssueModel>('Issue', issueSchema);

--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -1,4 +1,4 @@
-import { Schema, Document, model } from 'mongoose';
+import { Schema, Document, model, Model } from 'mongoose';
 
 export interface IssueType {
   message: string;
@@ -22,7 +22,10 @@ export interface IssueType {
   };
 }
 
-export interface IssueTypeModel extends IssueType, Document {}
+export interface IssueDocument extends IssueType, Document {}
+export interface IssueModel extends Model<IssueDocument> {
+  build(attr: IssueType): IssueDocument;
+}
 
 const issueSchema = new Schema({
   message: { type: String, required: true },
@@ -53,10 +56,11 @@ const issueSchema = new Schema({
   },
 });
 
-const Issue = model<IssueTypeModel>('Issue', issueSchema);
-
-export const build = (issue: IssueType): IssueTypeModel => {
+issueSchema.statics.build = (issue: IssueType): IssueDocument => {
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   return new Issue(issue);
 };
+
+const Issue = model<IssueDocument, IssueModel>('Issue', issueSchema);
 
 export default Issue;

--- a/src/routes/issue/controllers/addIssue.ts
+++ b/src/routes/issue/controllers/addIssue.ts
@@ -1,11 +1,11 @@
 import { Context, Next } from 'koa';
-import { IssueType, IssueTypeModel, build } from '../../../models/Issue';
+import Issue, { IssueType, IssueDocument } from '../../../models/Issue';
 
-export default async (ctx: Context, next: Next) => {
+export default async (ctx: Context, next: Next): Promise<void> => {
   const newIssue: IssueType = ctx.request.body;
   newIssue.meta.ip = ctx.header.host;
   try {
-    const newIssueDoc: IssueTypeModel = build(newIssue);
+    const newIssueDoc: IssueDocument = Issue.build(newIssue);
     await newIssueDoc.save();
     ctx.response.status = 200;
   } catch (e) {

--- a/src/routes/issue/controllers/devDeleteIssues.ts
+++ b/src/routes/issue/controllers/devDeleteIssues.ts
@@ -6,7 +6,7 @@ import Issue from '../../../models/Issue';
  * @개발용
  * 전체 데이터 삭제 API
  */
-export default async (ctx: Context, next: Next) => {
+export default async (ctx: Context, next: Next): Promise<void> => {
   await Issue.deleteMany({});
   ctx.response.status = 200;
   await next();

--- a/src/routes/issue/controllers/getIssue.ts
+++ b/src/routes/issue/controllers/getIssue.ts
@@ -1,9 +1,9 @@
 import { Context, Next } from 'koa';
-import Issue, { IssueTypeModel } from '../../../models/Issue';
+import Issue, { IssueDocument } from '../../../models/Issue';
 
-export default async (ctx: Context, next: Next) => {
+export default async (ctx: Context, next: Next): Promise<void> => {
   const { issueId } = ctx.params;
-  const result: IssueTypeModel | null = await Issue.findOne({ _id: issueId });
+  const result: IssueDocument | null = await Issue.findOne({ _id: issueId });
   /**
    * @TODO
    * null 처리 필요

--- a/src/routes/issue/controllers/getIssues.ts
+++ b/src/routes/issue/controllers/getIssues.ts
@@ -1,8 +1,8 @@
 import { Context, Next } from 'koa';
-import Issue, { IssueTypeModel } from '../../../models/Issue';
+import Issue, { IssueDocument } from '../../../models/Issue';
 
-export default async (ctx: Context, next: Next) => {
-  const result: IssueTypeModel[] = await Issue.find();
+export default async (ctx: Context, next: Next): Promise<void> => {
+  const result: IssueDocument[] = await Issue.find();
   ctx.body = result;
 
   await next();

--- a/src/routes/issue/controllers/index.ts
+++ b/src/routes/issue/controllers/index.ts
@@ -2,7 +2,7 @@ import filenames from '../../../utils/filenames';
 
 const controllerNames = filenames(__dirname);
 
-export default async () => {
+export default async (): Promise<Record<string, unknown>> => {
   const controllerModules: Record<string, unknown> = {};
   await controllerNames.forEach(async (controllerName) => {
     const controller = await import(`./${controllerName}`);


### PR DESCRIPTION
### 구현의도
- Issue 모델 부분에서 build 메소드를 statics에 추가해서 사용할 수 있게 함.
- 기존에 있던 타입들을 수정하고, IssueDocument, Model 타입을 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)

```
issueSchema.statics.build = (issue: IssueType): IssueDocument => {
  // eslint-disable-next-line @typescript-eslint/no-use-before-define
  return new Issue(issue);
};
```
- build 메소드를 statics에 추가하는 경우 위와 같이 nu-use-before-define에 걸림. 하지만 작동은 정상적으로 이루어짐.
- 이 부분에 대해서 어떻게 하는 게 좋을지 모르겠음
- 기존에 있던 build 방식을 사용할건지 vs Issue.build를 사용하기 위해 statics를 사용할건지 의논했으면 좋겠음.
