### PR TITLE
stats api 리팩토링, issues api stack 수정, pagination api

### DIFF
--- a/src/routes/issue/controllers/devAddIssues.ts
+++ b/src/routes/issue/controllers/devAddIssues.ts
@@ -7,7 +7,7 @@ import makeDaySampleIssues from '../../../models/sampleIssues';
  * @개발용
  * 전체 데이터 삭제 API
  */
-export default async (ctx: Context, next: Next) => {
+export default async (ctx: Context, next: Next): Promise<void> => {
   await Issue.insertMany(makeDaySampleIssues());
   ctx.response.status = 200;
   await next();

--- a/src/routes/issue/controllers/getIssues.ts
+++ b/src/routes/issue/controllers/getIssues.ts
@@ -2,7 +2,9 @@ import { Context, Next } from 'koa';
 import Issue, { IssueDocument } from '../../../models/Issue';
 
 export default async (ctx: Context, next: Next): Promise<void> => {
-  const result: IssueDocument[] = await Issue.find();
+  const result: IssueDocument[] = await Issue.aggregate([
+    { $addFields: { stack: { $arrayElemAt: ['$stack', 0] } } },
+  ]);
   ctx.body = result;
 
   await next();

--- a/src/routes/issue/controllers/getIssues.ts
+++ b/src/routes/issue/controllers/getIssues.ts
@@ -1,9 +1,28 @@
 import { Context, Next } from 'koa';
 import Issue, { IssueDocument } from '../../../models/Issue';
 
+const CONTENT_PER_PAGE = 20;
+
 export default async (ctx: Context, next: Next): Promise<void> => {
-  const result: IssueDocument[] = await Issue.aggregate([
+  const page: number = parseInt(ctx.query.page, 10) || 1;
+  const [result]: IssueDocument[] = await Issue.aggregate([
     { $addFields: { stack: { $arrayElemAt: ['$stack', 0] } } },
+    {
+      $sort: {
+        occuredAt: -1,
+      },
+    },
+    {
+      $facet: {
+        metaData: [
+          { $count: 'total' },
+          { $addFields: { totalPage: { $ceil: { $divide: ['$total', CONTENT_PER_PAGE] } } } },
+          { $addFields: { page } },
+          { $addFields: { countPerPage: CONTENT_PER_PAGE } },
+        ],
+        data: [{ $skip: (page - 1) * CONTENT_PER_PAGE }, { $limit: CONTENT_PER_PAGE }],
+      },
+    },
   ]);
   ctx.body = result;
 

--- a/src/routes/issue/router.ts
+++ b/src/routes/issue/router.ts
@@ -2,7 +2,7 @@ import Router from 'koa-router';
 
 import controllers from './controllers';
 
-export default async () => {
+export default async (): Promise<Record<string, unknown>> => {
   const router = new Router();
   const controll: any = await controllers();
 

--- a/src/routes/stats/controllers/getStats.ts
+++ b/src/routes/stats/controllers/getStats.ts
@@ -1,59 +1,23 @@
 import { Context, Next } from 'koa';
-import Issue, { IssueTypeModel } from '../../../models/Issue';
-import { getPeriodByMillisec, getDefaultInterval } from '../services/statUtil';
+import Issue, { IssueDocument } from '../../../models/Issue';
+import { getPeriodByMillisec, getDefaultInterval, getStatsAggregate } from '../services/statUtil';
 
-interface Recent {
+interface StatQuery {
   type: string;
   period: string;
   interval: string;
+  start?: string;
+  end?: string;
 }
 
-interface Manual extends Recent {
-  start: string;
-  end: string;
-}
-
-export default async (ctx: Context, next: Next) => {
-  const params: Recent | Manual = ctx.query;
-
+export default async (ctx: Context, next: Next): Promise<void> => {
+  const params: StatQuery = ctx.query;
   const period: number = getPeriodByMillisec(params.period);
   const interval: number = getDefaultInterval(params.period, params.interval);
-  const start: Date = new Date(Date.now() - period); // 현재 - 구할 시간
+  const start: Date = params.start ? new Date(params.start) : new Date(Date.now() - period); // 현재 - 구할 시간
+  const end: Date = params.end ? new Date(params.end) : new Date();
 
-  const result: IssueTypeModel[] = await Issue.aggregate([
-    // 1. 지금 시간부터 period를 뺀 시간까지의 데이터의 occuredAt을 추출한다.
-    { $match: { occuredAt: { $gte: start, $lte: new Date() } } },
-    // 2. (occuredAt - 시간 기본값) - ((occuredAt - 시간 기본값) % interval)으로 시간을 나누어 그룹핑해주고, 그룹마다 count에 1을 더해준다.
-    // mod기 때문에 나머지 초가 없어진다.
-    {
-      $group: {
-        _id: {
-          $subtract: [
-            { $subtract: ['$occuredAt', new Date('1970-01-01')] },
-            { $mod: [{ $subtract: ['$occuredAt', new Date('1970-01-01')] }, interval] },
-          ],
-        },
-        count: {
-          $sum: 1,
-        },
-      },
-    },
-    // 3. _id에 저장되어있던 occuredAt의 시간을 date 객체 형태로 추출해준다.
-    // 기존의 id를 제거하기 위해 _id:0을 해준다. (원리는 모르겠음)
-    {
-      $project: {
-        occuredAt: { $convert: { input: '$_id', to: 'date' } },
-        count: '$count',
-        _id: 0,
-      },
-    },
-    // 4. 오름차순으로 정렬해준다.
-    {
-      $sort: {
-        occuredAt: 1,
-      },
-    },
-  ]);
+  const result: IssueDocument[] = await Issue.aggregate(getStatsAggregate(interval, start, end));
   ctx.body = result;
 
   await next();

--- a/src/routes/stats/controllers/index.ts
+++ b/src/routes/stats/controllers/index.ts
@@ -2,7 +2,7 @@ import filenames from '../../../utils/filenames';
 
 const controllerNames = filenames(__dirname);
 
-export default async () => {
+export default async (): Promise<Record<string, unknown>> => {
   const controllerModules: Record<string, unknown> = {};
   await controllerNames.forEach(async (controllerName) => {
     const controller = await import(`./${controllerName}`);

--- a/src/routes/stats/router.ts
+++ b/src/routes/stats/router.ts
@@ -2,7 +2,7 @@ import Router from 'koa-router';
 
 import controllers from './controllers';
 
-export default async () => {
+export default async (): Promise<Record<string, unknown>> => {
   const router = new Router();
   const controll: any = await controllers();
 

--- a/src/routes/stats/services/statUtil.ts
+++ b/src/routes/stats/services/statUtil.ts
@@ -31,4 +31,41 @@ const getDefaultInterval = (period: string, interval: string | undefined): numbe
   return PERIOD_INTERVAL_MAP[period];
 };
 
-export { getPeriodByMillisec, getDefaultInterval };
+const getStatsAggregate = (interval: number, start: Date, end: Date): Record<string, unknown>[] => {
+  return [
+    // 1. 지금 시간부터 period를 뺀 시간까지의 데이터의 occuredAt을 추출한다.
+    { $match: { occuredAt: { $gte: start, $lte: end } } },
+    // 2. (occuredAt - 시간 기본값) - ((occuredAt - 시간 기본값) % interval)으로 시간을 나누어 그룹핑해주고, 그룹마다 count에 1을 더해준다.
+    // mod기 때문에 나머지 초가 없어진다.
+    {
+      $group: {
+        _id: {
+          $subtract: [
+            { $subtract: ['$occuredAt', new Date('1970-01-01')] },
+            { $mod: [{ $subtract: ['$occuredAt', new Date('1970-01-01')] }, interval] },
+          ],
+        },
+        count: {
+          $sum: 1,
+        },
+      },
+    },
+    // 3. _id에 저장되어있던 occuredAt의 시간을 date 객체 형태로 추출해준다.
+    // 기존의 id를 제거하기 위해 _id:0을 해준다. (원리는 모르겠음)
+    {
+      $project: {
+        occuredAt: { $convert: { input: '$_id', to: 'date' } },
+        count: '$count',
+        _id: 0,
+      },
+    },
+    // 4. 오름차순으로 정렬해준다.
+    {
+      $sort: {
+        occuredAt: 1,
+      },
+    },
+  ];
+};
+
+export { getPeriodByMillisec, getDefaultInterval, getStatsAggregate };


### PR DESCRIPTION
### 구현의도
- getStats의 aggregate 내부 변수 util 함수로 분리
  `aggregate` 내부 변수가 너무 길기 때문에, 내부 변수를 리턴해주는 함수 추가

- manual 기능 추가
  기존 `Manual`과 `Recent` 타입을 `StatQuery` 타입으로 통일
  `aggregate`의 `$match`에 시작, 종료 기간 값 수정

- Router, Controller 리턴 타입 추가

- issues api stack 수정
  stack에 첫 번째 stack 정보만 들어있도록 수정.

- pagination API 추가
  - stack 필드에 첫 stack 정보만 나오도록

  - 최근 issue가 먼저 나오도록

  - 데이터에 metaData 추가
  전체 issue 개수, 전체 페이지 개수, 현재 페이지 번호, 페이지당 issue 개수
### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
