### PR TITLE
프로젝트 리스트 api에 유저 populate 추가

### DIFF
--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -19,8 +19,8 @@ export interface ProjectModel extends Model<ProjectDocument> {
 const projectSchema = new Schema({
   name: { type: String, required: true },
   description: { type: String },
-  owner: { type: Schema.Types.ObjectId, required: true },
-  users: { type: Schema.Types.Array, required: true },
+  owner: { type: Schema.Types.ObjectId, required: true, ref: 'User' },
+  users: [{ type: Schema.Types.ObjectId, required: true, ref: 'User' }],
 });
 
 projectSchema.statics.build = function buildProject(project: IProject) {

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -7,13 +7,13 @@ export interface IProject {
   users: string[];
 }
 
-export interface ProjectDocument extends IProject, Document {
+export interface IProjectDocument extends IProject, Document {
   addUser(user: string): Promise<void>;
   deleteUser(user: string): Promise<void>;
 }
 
-export interface ProjectModel extends Model<ProjectDocument> {
-  build(attr: IProject): ProjectDocument;
+export interface IProjectModel extends Model<IProjectDocument> {
+  build(attr: IProject): IProjectDocument;
 }
 
 const projectSchema = new Schema({
@@ -34,5 +34,5 @@ projectSchema.methods.addUser = function addUser(userId: string) {
 projectSchema.methods.deleteUser = function deleteUser(userId: string) {
   this.users.pull(userId);
 };
-const Project = model<ProjectDocument, ProjectModel>('Project', projectSchema);
+const Project = model<IProjectDocument, IProjectModel>('Project', projectSchema);
 export default Project;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -7,12 +7,12 @@ export interface IUser {
   projects: string[];
 }
 
-export interface UserDocument extends IUser, Document {
+export interface IUserDocument extends IUser, Document {
   addProject(projectId: string): void;
   deleteProject(projectId: string): void;
 }
-export interface UserModel extends Model<UserDocument> {
-  build(attr: IUser): UserDocument;
+export interface IUserModel extends Model<IUserDocument> {
+  build(attr: IUser): IUserDocument;
 }
 
 const userSchema = new Schema({
@@ -25,7 +25,7 @@ const userSchema = new Schema({
   },
 });
 
-userSchema.statics.build = function buildUser(user: IUser): UserDocument {
+userSchema.statics.build = function buildUser(user: IUser): IUserDocument {
   return new this(user);
 };
 
@@ -37,6 +37,6 @@ userSchema.methods.deleteProject = function deleteProject(projectId: string) {
   this.projects.pull(projectId);
 };
 
-const User = model<UserDocument, UserModel>('User', userSchema);
+const User = model<IUserDocument, IUserModel>('User', userSchema);
 
 export default User;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -7,7 +7,10 @@ export interface IUser {
   projects: string[];
 }
 
-export interface UserDocument extends IUser, Document {}
+export interface UserDocument extends IUser, Document {
+  addProject(projectId: string): void;
+  deleteProject(projectId: string): void;
+}
 export interface UserModel extends Model<UserDocument> {
   build(attr: IUser): UserDocument;
 }
@@ -16,7 +19,10 @@ const userSchema = new Schema({
   uid: { type: Number, required: true },
   nickname: { type: String, required: true },
   email: { type: String },
-  projects: { type: Schema.Types.Array, required: true, default: [] },
+  projects: {
+    type: [{ type: Schema.Types.ObjectId, required: true, ref: 'Project' }],
+    default: [],
+  },
 });
 
 userSchema.statics.build = function buildUser(user: IUser): UserDocument {

--- a/src/routes/auth/controllers/githubCallback.ts
+++ b/src/routes/auth/controllers/githubCallback.ts
@@ -1,5 +1,5 @@
 import { Context, Next } from 'koa';
-import { UserDocument } from '../../../models/User';
+import { IUserDocument } from '../../../models/User';
 import { processGithubOAuth, getToken } from '../services/githubUtil';
 
 const HOUR: number = 1000 * 60 * 60;
@@ -15,7 +15,7 @@ export default async (ctx: Context, next: Next): Promise<void> => {
     return;
   }
   const accessCode: string = ctx.query.code;
-  const newUser: UserDocument = (await processGithubOAuth(accessCode)) as UserDocument;
+  const newUser: IUserDocument = (await processGithubOAuth(accessCode)) as IUserDocument;
   const jwtToken: string = getToken(newUser, tokenExpiration);
   if (jwtToken) {
     ctx.cookies.set('nickname', newUser.nickname, { httpOnly: false, maxAge: tokenExpiration });

--- a/src/routes/auth/services/githubUtil.ts
+++ b/src/routes/auth/services/githubUtil.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
 import jwt from 'jsonwebtoken';
-import User, { UserDocument } from '../../../models/User';
+import User, { IUserDocument } from '../../../models/User';
 
 interface IProfile {
   id: number;
@@ -8,7 +8,7 @@ interface IProfile {
   email: string;
 }
 
-const insertUser = async (profile: IProfile): Promise<UserDocument | null> => {
+const insertUser = async (profile: IProfile): Promise<IUserDocument | null> => {
   const { id: uid, login: nickname, email }: IProfile = profile;
   const result = await User.findOneAndUpdate(
     { uid },
@@ -20,7 +20,7 @@ const insertUser = async (profile: IProfile): Promise<UserDocument | null> => {
   return result;
 };
 
-const processGithubOAuth = async (code: string): Promise<UserDocument | null> => {
+const processGithubOAuth = async (code: string): Promise<IUserDocument | null> => {
   const accessResponse = await fetch(
     `https://github.com/login/oauth/access_token?client_id=${
       process.env.NODE_ENV === 'development'
@@ -49,11 +49,11 @@ const processGithubOAuth = async (code: string): Promise<UserDocument | null> =>
     },
   });
   const profile: IProfile = await profileResponse.json();
-  const newUser: UserDocument | null = await insertUser(profile);
+  const newUser: IUserDocument | null = await insertUser(profile);
   return newUser;
 };
 
-const getToken = (newUser: UserDocument, tokenExpiration: number): string => {
+const getToken = (newUser: IUserDocument, tokenExpiration: number): string => {
   // eslint-disable-next-line no-underscore-dangle
   const userId: string = newUser._id;
   const jwtSecret: string = process.env.JWT_SECRET as string;

--- a/src/routes/project/controllers/addProject.ts
+++ b/src/routes/project/controllers/addProject.ts
@@ -1,4 +1,5 @@
 import { Context } from 'koa';
+import User, { UserDocument } from '../../../models/User';
 import Project, { IProject, ProjectDocument } from '../../../models/Project';
 
 interface IBody {
@@ -8,6 +9,8 @@ interface IBody {
 
 export default async (ctx: Context): Promise<void> => {
   const req: IBody = ctx.request.body;
+  const user: UserDocument | null = await User.findOne({ _id: ctx.state.user._id });
+  if (!user) ctx.throw(404, 'user not found');
   const newProject: IProject = {
     ...req,
     owner: ctx.state.user._id,
@@ -16,6 +19,8 @@ export default async (ctx: Context): Promise<void> => {
   try {
     const newProjectDoc: ProjectDocument = Project.build(newProject);
     await newProjectDoc.save();
+    user.addProject(newProjectDoc._id);
+    await user.save();
     ctx.body = { projectId: newProjectDoc._id };
     ctx.response.status = 201;
   } catch (e) {

--- a/src/routes/project/controllers/addProject.ts
+++ b/src/routes/project/controllers/addProject.ts
@@ -1,6 +1,6 @@
 import { Context } from 'koa';
-import User, { UserDocument } from '../../../models/User';
-import Project, { IProject, ProjectDocument } from '../../../models/Project';
+import User, { IUserDocument } from '../../../models/User';
+import Project, { IProject, IProjectDocument } from '../../../models/Project';
 
 interface IBody {
   name: string;
@@ -9,7 +9,7 @@ interface IBody {
 
 export default async (ctx: Context): Promise<void> => {
   const req: IBody = ctx.request.body;
-  const user: UserDocument | null = await User.findOne({ _id: ctx.state.user._id });
+  const user: IUserDocument | null = await User.findOne({ _id: ctx.state.user._id });
   if (!user) ctx.throw(404, 'user not found');
   const newProject: IProject = {
     ...req,
@@ -17,7 +17,7 @@ export default async (ctx: Context): Promise<void> => {
     users: [],
   };
   try {
-    const newProjectDoc: ProjectDocument = Project.build(newProject);
+    const newProjectDoc: IProjectDocument = Project.build(newProject);
     await newProjectDoc.save();
     user.addProject(newProjectDoc._id);
     await user.save();

--- a/src/routes/project/controllers/getProjects.ts
+++ b/src/routes/project/controllers/getProjects.ts
@@ -26,6 +26,8 @@ export default async (ctx: Context): Promise<void> => {
   }
   try {
     let projects = await Project.find()
+      .populate('owner')
+      .populate('users')
       .where('_id')
       .in(userDocument.projects.map((projectId: string) => Types.ObjectId(projectId)));
     if (userType === UserEnum.OWNER) {

--- a/src/routes/project/controllers/getProjects.ts
+++ b/src/routes/project/controllers/getProjects.ts
@@ -21,9 +21,7 @@ export default async (ctx: Context): Promise<void> => {
   const { userType = UserEnum.ALL }: IQuery = ctx.query;
   const { user } = ctx.state as IState;
   const userDocument = await User.findOne({ _id: user._id });
-  if (!userDocument) {
-    return;
-  }
+  if (!userDocument) ctx.throw(404, 'user not found');
   try {
     let projects = await Project.find()
       .populate('owner')


### PR DESCRIPTION
### 구현의도
- project가 가지고 있는 users에 대한 값을 populate를 이용해서 전체 값을 불러옴(owner도 마찬가지)
- addProject 부분에 user에 project를 추가하지 않는 부분을 수정

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
