### PR TITLE
project owner 변경 API / get user api / 기타 리팩토링

### DIFF
--- a/src/routes/project/controllers/deleteProject.ts
+++ b/src/routes/project/controllers/deleteProject.ts
@@ -2,13 +2,14 @@ import { Context } from 'koa';
 import Project from '../../../models/Project';
 
 interface IQuery {
-  id: number;
+  id: string;
 }
 
 export default async (ctx: Context): Promise<void> => {
   const { id: projectId }: IQuery = ctx.params;
   try {
-    await Project.findOne({ _id: projectId }).remove();
+    // await Project.findOne({ _id: projectId }).remove();
+    await Project.deleteOne({ _id: projectId });
   } catch (e) {
     ctx.throw(400, 'internal server error');
   }

--- a/src/routes/project/controllers/deleteProjectUsers.ts
+++ b/src/routes/project/controllers/deleteProjectUsers.ts
@@ -2,7 +2,7 @@ import { Context } from 'koa';
 import Project from '../../../models/Project';
 
 interface IQuery {
-  id: number;
+  id: string;
 }
 
 interface IBody {

--- a/src/routes/project/controllers/getProject.ts
+++ b/src/routes/project/controllers/getProject.ts
@@ -1,9 +1,8 @@
 import { Context } from 'koa';
-import Project, { IProjectDocument } from '../../../models/Project';
-import User from '../../../models/User';
+import Project from '../../../models/Project';
 
 interface IQuery {
-  id: number;
+  id: string;
 }
 
 export default async (ctx: Context): Promise<void> => {

--- a/src/routes/project/controllers/updateProjectName.ts
+++ b/src/routes/project/controllers/updateProjectName.ts
@@ -2,7 +2,7 @@ import { Context } from 'koa';
 import Project from '../../../models/Project';
 
 interface IQuery {
-  id: number;
+  id: string;
 }
 
 interface IBody {

--- a/src/routes/project/controllers/updateProjectOwner.ts
+++ b/src/routes/project/controllers/updateProjectOwner.ts
@@ -14,6 +14,11 @@ interface IBody {
 export default async (ctx: Context): Promise<void> => {
   const { id: projectId }: IParams = ctx.params;
   const { originUserId, targetUserId }: IBody = ctx.request.body;
+
+  if (ctx.state.user._id !== originUserId) {
+    throw Error();
+  }
+
   try {
     const targetUserCount = await User.countDocuments({ _id: targetUserId });
     const projectOwnerCount = await Project.countDocuments({ _id: projectId, owner: originUserId });

--- a/src/routes/project/controllers/updateProjectOwner.ts
+++ b/src/routes/project/controllers/updateProjectOwner.ts
@@ -1,0 +1,28 @@
+import { Context } from 'koa';
+import Project from '../../../models/Project';
+import User from '../../../models/User';
+
+interface IParams {
+  id: string;
+}
+
+interface IBody {
+  originUserId: string;
+  targetUserId: string;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { id: projectId }: IParams = ctx.params;
+  const { originUserId, targetUserId }: IBody = ctx.request.body;
+  try {
+    const targetUserCount = await User.countDocuments({ _id: targetUserId });
+    const projectOwnerCount = await Project.countDocuments({ _id: projectId, owner: originUserId });
+    if (targetUserCount !== 1 || projectOwnerCount !== 1) {
+      throw Error();
+    }
+    await Project.update({ _id: projectId }, { owner: targetUserId });
+  } catch (e) {
+    ctx.throw(400, 'internal server error');
+  }
+  ctx.status = 200;
+};

--- a/src/routes/project/router.ts
+++ b/src/routes/project/router.ts
@@ -18,6 +18,7 @@ export default async (): Promise<Record<string, unknown>> => {
   // put
   router.put('/project/name/:id', controller.updateProjectName);
   router.put('/project/:id/users', controller.deleteProjectUsers);
+  router.put('/project/:id/user', controller.updateProjectOwner);
 
   // delete
   router.delete('/project/:id', controller.deleteProject);

--- a/src/routes/test/controllers/addUsers.ts
+++ b/src/routes/test/controllers/addUsers.ts
@@ -1,0 +1,35 @@
+/**
+ * Project에 4명의 user를 추가하는 테스트용 API 입니다.
+ */
+
+import { Context } from 'koa';
+import Project from '../../../models/Project';
+
+interface IQuery {
+  id: string;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { id: projectId }: IQuery = ctx.params;
+  try {
+    await Project.updateOne(
+      { _id: projectId },
+      {
+        $push: {
+          users: {
+            $each: [
+              '5fc5d0f738d1839a9be86541',
+              '5fc7033438d1839a9b14bd79',
+              '5fc7205838d1839a9b191373',
+              '5fc728ba38d1839a9b1a65e2',
+            ],
+          },
+        },
+      },
+      { upsert: true },
+    );
+    ctx.status = 200;
+  } catch (e) {
+    ctx.throw(400, 'internal server error');
+  }
+};

--- a/src/routes/test/router.ts
+++ b/src/routes/test/router.ts
@@ -11,6 +11,7 @@ export default async (): Promise<Record<string, unknown>> => {
 
   //   post
   router.post('/test', controller.addTest);
+  router.post('/test/project/:id', controller.addUsers);
   //   put
   //   delete
   return router;

--- a/src/routes/user/controllers/getUser.ts
+++ b/src/routes/user/controllers/getUser.ts
@@ -1,0 +1,17 @@
+import { Context, Next } from 'koa';
+import User from '../../../models/User';
+
+interface IParams {
+  id: string;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { id: userId }: IParams = ctx.params;
+  try {
+    const result = await User.findById(userId);
+    if (result === null) throw Error();
+    ctx.body = result;
+  } catch (e) {
+    ctx.throw(500);
+  }
+};

--- a/src/routes/user/controllers/index.ts
+++ b/src/routes/user/controllers/index.ts
@@ -1,0 +1,12 @@
+import filenames from '../../../utils/filenames';
+
+const controllerNames = filenames(__dirname);
+
+export default async (): Promise<Record<string, unknown>> => {
+  const controllerModules: Record<string, unknown> = {};
+  await controllerNames.forEach(async (controllerName) => {
+    const controller = await import(`./${controllerName}`);
+    controllerModules[controllerName] = controller.default;
+  });
+  return controllerModules;
+};

--- a/src/routes/user/router.ts
+++ b/src/routes/user/router.ts
@@ -1,0 +1,13 @@
+import Router from 'koa-router';
+
+import controllers from './controllers';
+
+export default async (): Promise<Record<string, unknown>> => {
+  const router = new Router();
+  const controller: any = await controllers();
+
+  //   get
+  router.get('/user/:id', controller.getUser);
+
+  return router;
+};


### PR DESCRIPTION
### 구현의도
- Project owner 변경 API
   project의 현재 owner validation, target owner validation후 owner 변경

- 사용자 정보를 얻어오는 api 추가

- Project 삭제 api 의 id 타입 `number` -> `string` 수정

- Project에 user를 추가하는 test api 생성


### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
