### PR TITLE
이슈 Open / Close 기능 API 추가 

### DIFF
--- a/src/models/Issue.ts
+++ b/src/models/Issue.ts
@@ -6,6 +6,7 @@ export interface IIssue {
   type: string;
   stack: { columnNo: string; lineNo: string; function: string; filename: string }[];
   errorIds: string[];
+  isOpen: boolean;
 }
 
 export interface IIssueDocument extends IIssue, Document {
@@ -22,6 +23,7 @@ const issueSchema = new Schema({
   type: String,
   stack: { type: Schema.Types.Array, required: true },
   errorIds: { type: Schema.Types.Array, required: true },
+  isOpen: { type: Schema.Types.Boolean, require: true },
 });
 
 issueSchema.statics.build = function buildIssue(issue: IIssue): IIssueDocument {

--- a/src/routes/error/controllers/addError.ts
+++ b/src/routes/error/controllers/addError.ts
@@ -17,6 +17,7 @@ export default async (ctx: Context, next: Next): Promise<void> => {
         message: newError.message,
         stack: newError.stack,
         type: newError.type,
+        isOpen: true,
       },
       {
         $push: { errorIds: res._id },

--- a/src/routes/issue/controllers/updateIssueIsOpen.ts
+++ b/src/routes/issue/controllers/updateIssueIsOpen.ts
@@ -1,0 +1,21 @@
+import { Context } from 'koa';
+import Issue from '../../../models/Issue';
+
+interface IQuery {
+  issueId: string;
+}
+
+interface IBody {
+  ids: string[];
+  isOpen: boolean;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { ids, isOpen }: IBody = ctx.request.body;
+  try {
+    await Issue.updateMany({ _id: { $in: ids } }, { $set: { isOpen } });
+  } catch (e) {
+    ctx.throw(500, 'internal server error');
+  }
+  ctx.status = 200;
+};

--- a/src/routes/issue/router.ts
+++ b/src/routes/issue/router.ts
@@ -11,7 +11,7 @@ export default async (): Promise<Record<string, unknown>> => {
   router.get('/issue/:issueId', controller.getIssue);
 
   //   put
-  router.put('/issues/', controll.updateIssueIsOpen);
+  router.put('/issues/', controller.updateIssueIsOpen);
 
   return router;
 };

--- a/src/routes/issue/router.ts
+++ b/src/routes/issue/router.ts
@@ -11,6 +11,7 @@ export default async (): Promise<Record<string, unknown>> => {
   router.get('/issue/:issueId', controller.getIssue);
 
   //   put
+  router.put('/issues/', controll.updateIssueIsOpen);
 
   return router;
 };


### PR DESCRIPTION
### 구현의도
- 복수의 이슈들을 Open / Close 처리하기 위한 API를 작성하였습니다. 

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 복수 API가 단일 이슈 close / open API를 겸용할 수 있어 단일 API는 별도 구현하지 않았습니다.  
