### PR TITLE
Error 발생한 사용자 IP 확인기능 추가

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ require('dotenv').config();
 const PORT = process.env.PORT || 4000;
 
 const app = new Koa();
+app.proxy = true;
 
 app.use(json());
 app.use(bodyParser());

--- a/src/routes/error/controllers/addError.ts
+++ b/src/routes/error/controllers/addError.ts
@@ -7,7 +7,7 @@ import Issue from '../../../models/Issue';
 export default async (ctx: Context, next: Next): Promise<void> => {
   const newError: IError = ctx.request.body;
   const { projectId } = ctx.params;
-  newError.meta.ip = ctx.header.host;
+  newError.meta.ip = ctx.request.ip;
   try {
     const newErrorDoc: IErrorDocument = Error.build(newError);
     const res = await newErrorDoc.save();


### PR DESCRIPTION
### 구현의도
- 임시로 host로 설정되어있던 값을 ip로 변경
- 이슈 안에서 에러를 겪은 사용자 수를 계산 목적
- ErrorList 컴포넌트 구현 시 IP 보여줄 목적

### 기능 흐름도, 클래스 다이어그램(선택사항)
![예시](https://i.imgur.com/SmvUEJ8.png)

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 서버 코드를 별도의 nCloud 서버에 띄워서 ip 잡히는 것 확인하였습니다. 