### PR TITLE
getIssues API에 userIps 추가

### DIFF
--- a/src/routes/issue/controllers/getIssues.ts
+++ b/src/routes/issue/controllers/getIssues.ts
@@ -2,7 +2,7 @@ import { Context, Next } from 'koa';
 import { Types } from 'mongoose';
 import Issue, { IIssueDocument } from '../../../models/Issue';
 
-const CONTENT_PER_PAGE = 20;
+const CONTENT_PER_PAGE = 15;
 
 export default async (ctx: Context, next: Next): Promise<void> => {
   let { projectId } = ctx.query;
@@ -28,12 +28,48 @@ export default async (ctx: Context, next: Next): Promise<void> => {
         as: 'project',
       },
     },
+
+    { $addFields: { lastErrorId: { $arrayElemAt: ['$errorIds', 0] } } },
     {
       $lookup: {
+        localField: 'lastErrorId',
+        // localField: 'errorIds',
+        from: 'errors',
+        foreignField: '_id',
+        as: 'lastError',
+      },
+    },
+
+    { $unwind: '$lastError' },
+    {
+      $lookup: {
+        // localField: 'lastErrorId',
         localField: 'errorIds',
         from: 'errors',
         foreignField: '_id',
-        as: 'errors',
+        as: 'totalError',
+      },
+    },
+
+    {
+      $group: {
+        _id: {
+          _id: '$_id',
+          meta: '$meta',
+          type: '$type',
+          message: '$message',
+          stack: '$stack',
+          lastError: '$lastError',
+          project: '$project',
+          errorIds: '$errorIds',
+        },
+        /**
+         * @todo
+         * unique 적용되도록 수정해야함
+         * + count해서 반환하도록 수정
+         */
+
+        _stat: { $addToSet: { userIps: '$totalError.meta.ip' } },
       },
     },
     {
@@ -52,7 +88,9 @@ export default async (ctx: Context, next: Next): Promise<void> => {
         data: [{ $skip: (page - 1) * CONTENT_PER_PAGE }, { $limit: CONTENT_PER_PAGE }],
       },
     },
+    { $unwind: '$metaData' }, // metadata 배열 해제
   ]);
+
   ctx.body = result;
 
   await next();


### PR DESCRIPTION

### 구현의도
- 이슈 목록에서 사용할 유저 갯수 파악을 위해 api 수정
- 이슈별 전체 ip 목록을반화
- addToSet을 통해 고유값으로 지정하려했으나 동작하지 않아서 추후 리팩토링 필요


### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
