### PR TITLE
점유율 그래프 통계 API 추가

### DIFF
--- a/src/models/Crime.ts
+++ b/src/models/Crime.ts
@@ -5,6 +5,7 @@ export interface ICrime {
   type: string;
   stack: { columnNo: string; lineNo: string; function: string; filename: string }[];
   occuredAt: Date;
+  projectId: string;
   sdk: {
     name: string;
     version: string;
@@ -40,6 +41,7 @@ const CrimeSchema = new Schema({
     },
   ],
   occuredAt: { type: Date, required: true },
+  projectId: { type: String, require: true },
   sdk: {
     name: { type: String, required: true },
     version: { type: String, required: true },

--- a/src/models/sampleCrimes.ts
+++ b/src/models/sampleCrimes.ts
@@ -22,6 +22,7 @@ const makeSampleIssueWithTime = (date: Date): ICrime => {
     },
     message: 'error maker made this',
     type: 'sample type',
+    projectId: 'sample project id',
     stack: [
       {
         columnNo: '9',

--- a/src/routes/crime/controllers/addCrime.ts
+++ b/src/routes/crime/controllers/addCrime.ts
@@ -7,6 +7,7 @@ import Issue from '../../../models/Issue';
 export default async (ctx: Context, next: Next): Promise<void> => {
   const newCrime: ICrime = ctx.request.body;
   const { projectId } = ctx.params;
+  newCrime.projectId = projectId;
   newCrime.meta.ip = ctx.request.ip;
   try {
     const newCrimeDoc: ICrimeDocument = Crime.build(newCrime);

--- a/src/routes/stats/controllers/getShares.ts
+++ b/src/routes/stats/controllers/getShares.ts
@@ -4,22 +4,27 @@ import { getPeriodByMillisec } from '../services/statUtil';
 import { getSharesAggregate } from '../services/sharesUtil';
 
 interface StatQuery {
+  projectId: string | string[];
   type: string;
   period: string;
-  interval: string;
   start?: string;
   end?: string;
 }
 
 export default async (ctx: Context, next: Next): Promise<void> => {
   const params: StatQuery = ctx.query;
+  let { projectId: projectIds } = params;
+
+  if (!Array.isArray(projectIds)) {
+    projectIds = [projectIds];
+  }
 
   const period: number = getPeriodByMillisec(params.period);
   const start: Date = params.start ? new Date(params.start) : new Date(Date.now() - period);
   const end: Date = params.end ? new Date(params.end) : new Date();
 
-  const result = await Crime.aggregate(getSharesAggregate(start, end));
-  ctx.body = result;
+  const [metas] = await Crime.aggregate(getSharesAggregate(projectIds, start, end));
+  ctx.body = metas;
 
   await next();
 };

--- a/src/routes/stats/controllers/getShares.ts
+++ b/src/routes/stats/controllers/getShares.ts
@@ -1,0 +1,25 @@
+import { Context, Next } from 'koa';
+import Crime from '../../../models/Crime';
+import { getPeriodByMillisec } from '../services/statUtil';
+import { getSharesAggregate } from '../services/sharesUtil';
+
+interface StatQuery {
+  type: string;
+  period: string;
+  interval: string;
+  start?: string;
+  end?: string;
+}
+
+export default async (ctx: Context, next: Next): Promise<void> => {
+  const params: StatQuery = ctx.query;
+
+  const period: number = getPeriodByMillisec(params.period);
+  const start: Date = params.start ? new Date(params.start) : new Date(Date.now() - period);
+  const end: Date = params.end ? new Date(params.end) : new Date();
+
+  const result = await Crime.aggregate(getSharesAggregate(start, end));
+  ctx.body = result;
+
+  await next();
+};

--- a/src/routes/stats/controllers/getShares.ts
+++ b/src/routes/stats/controllers/getShares.ts
@@ -33,9 +33,9 @@ export default async (ctx: Context, next: Next): Promise<void> => {
   const start: Date = params.start ? new Date(params.start) : new Date(Date.now() - period);
   const end: Date = params.end ? new Date(params.end) : new Date();
 
-  const issues = await Issue.aggregate(getIssueSharesAggregate(projectObjectIds, start, end));
+  const issue = await Issue.aggregate(getIssueSharesAggregate(projectObjectIds, start, end));
   const [metas] = await Crime.aggregate(getSharesAggregate(projectIds, start, end));
-  ctx.body = { issues, ...metas };
+  ctx.body = { issue, ...metas };
 
   await next();
 };

--- a/src/routes/stats/router.ts
+++ b/src/routes/stats/router.ts
@@ -7,6 +7,7 @@ export default async (): Promise<Record<string, unknown>> => {
   const controller: any = await controllers();
 
   //   get
+  router.get('/stats/shares', controller.getShares);
   router.get('/stats', controller.getStats);
 
   return router;

--- a/src/routes/stats/services/sharesUtil.ts
+++ b/src/routes/stats/services/sharesUtil.ts
@@ -10,9 +10,13 @@ const getGroupAndCountAggregate = (field: string) => {
   ];
 };
 
-const getSharesAggregate = (start: Date, end: Date): Record<string, unknown>[] => {
+const getSharesAggregate = (
+  projectIds: string[],
+  start: Date,
+  end: Date,
+): Record<string, unknown>[] => {
   return [
-    { $match: { occuredAt: { $gte: start, $lte: end } } },
+    { $match: { occuredAt: { $gte: start, $lte: end }, projectId: { $in: projectIds } } },
     {
       $facet: {
         browsers: getGroupAndCountAggregate('$meta.browser.name'),

--- a/src/routes/stats/services/sharesUtil.ts
+++ b/src/routes/stats/services/sharesUtil.ts
@@ -9,6 +9,7 @@ const getGroupAndCountAggregate = (field: string) => {
       },
     },
     { $project: { _id: 0, name: '$_id', count: 1 } },
+    { $sort: { count: -1 } },
   ];
 };
 
@@ -58,6 +59,7 @@ const getIssueSharesAggregate = (
     },
     { $unwind: '$crimeCount' },
     { $project: { _id: 1, type: 1, message: 1, count: '$crimeCount.value' } },
+    { $sort: { count: -1 } },
   ];
 };
 

--- a/src/routes/stats/services/sharesUtil.ts
+++ b/src/routes/stats/services/sharesUtil.ts
@@ -21,7 +21,7 @@ const getSharesAggregate = (
     { $match: { occuredAt: { $gte: start, $lte: end }, projectId: { $in: projectIds } } },
     {
       $facet: {
-        browsers: getGroupAndCountAggregate('$meta.browser.name'),
+        browser: getGroupAndCountAggregate('$meta.browser.name'),
         os: getGroupAndCountAggregate('$meta.os.name'),
         url: getGroupAndCountAggregate('$meta.url'),
       },

--- a/src/routes/stats/services/sharesUtil.ts
+++ b/src/routes/stats/services/sharesUtil.ts
@@ -1,0 +1,26 @@
+const getGroupAndCountAggregate = (field: string) => {
+  return [
+    {
+      $group: {
+        _id: field,
+        count: { $sum: 1 },
+      },
+    },
+    { $project: { _id: 0, name: '$_id', count: 1 } },
+  ];
+};
+
+const getSharesAggregate = (start: Date, end: Date): Record<string, unknown>[] => {
+  return [
+    { $match: { occuredAt: { $gte: start, $lte: end } } },
+    {
+      $facet: {
+        browsers: getGroupAndCountAggregate('$meta.browser.name'),
+        os: getGroupAndCountAggregate('$meta.os.name'),
+        url: getGroupAndCountAggregate('$meta.url'),
+      },
+    },
+  ];
+};
+
+export { getSharesAggregate };

--- a/src/routes/stats/services/statUtil.ts
+++ b/src/routes/stats/services/statUtil.ts
@@ -1,6 +1,7 @@
 const MINUTE_MILLISEC = 1000 * 60;
 const HOUR_MILLISEC = MINUTE_MILLISEC * 60;
 const DAY_MILLISEC = HOUR_MILLISEC * 24;
+const WEEK_MILLISEC = DAY_MILLISEC * 7;
 const MONTH_MILLISEC = DAY_MILLISEC * 30; // 30일로 가정
 
 const getPeriodByMillisec = (periodString: string): number => {
@@ -8,6 +9,9 @@ const getPeriodByMillisec = (periodString: string): number => {
   const time: number = parseInt(periodString.slice(0, -1), 10);
   if (unit === 'M') {
     return time * MONTH_MILLISEC;
+  }
+  if (unit === 'w') {
+    return time * WEEK_MILLISEC;
   }
   if (unit === 'd') {
     return time * DAY_MILLISEC;


### PR DESCRIPTION
### 구현의도
- Issue, Browser, OS, URL로 grouping 한 갯수를 가져올 수 있도록 API를 작성하였습니다. 

### 기능 흐름도, 클래스 다이어그램(선택사항)
- Request 주소: ```/api/stats/shares?projectId=5fcf7c6d70fc246340a7c37e&type=recent&period=1w```
- Response
```json
{
    "issues": [
        {
            "_id": "5fcf7c9817a95f43cef626d5",
            "message": "Cannot set property 'innerHTML' of null",
            "type": "TypeError",
            "count": 12
        },
        {
            "_id": "5fcf7c9b17a95f43cef62845",
            "message": "URI malformed",
            "type": "URIError",
            "count": 6
        },
        {
            "_id": "5fcf7d0c17a95f43cef635bc",
            "message": "error maker made this",
            "type": "Error",
            "count": 8
        }
    ],
    "browsers": [
        {
            "count": 26,
            "name": "Chrome"
        }
    ],
    "os": [
        {
            "count": 8,
            "name": "Android"
        },
        {
            "count": 18,
            "name": "Windows"
        }
    ],
    "url": [
        {
            "count": 26,
            "name": "http://localhost:9000/"
        }
    ]
}
```

### 사용된 기술(선택사항)
- MongoDB [lookup pipeline](https://docs.mongodb.com/master/reference/operator/aggregation/lookup/#uncorrelated-subquery)

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 