### PR TITLE
이슈 에러 빈도 그래프 데이터 api 추가

### DIFF
--- a/src/routes/stats/controllers/getCrimesCount.ts
+++ b/src/routes/stats/controllers/getCrimesCount.ts
@@ -1,0 +1,29 @@
+import { Context } from 'koa';
+import { getCrimesCountAggregate, setDefaultGroup } from '../services/crimesCount';
+import Issue from '../../../models/Issue';
+
+const MILLISECOND_OF_TWELVE_HOUR = 3600 * 24 * 1000;
+
+interface IParams {
+  issueId: string;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { issueId }: IParams = ctx.params;
+  const start = new Date(Date.now() - MILLISECOND_OF_TWELVE_HOUR);
+  const end = new Date(Date.now());
+  const INTERVAL_ONE_HOUR = 60 * 1000 * 60;
+  try {
+    const [result] = await Issue.aggregate(
+      getCrimesCountAggregate({ issueId, start, end, interval: INTERVAL_ONE_HOUR }),
+    );
+    const crimesByDate = setDefaultGroup({
+      start,
+      interval: INTERVAL_ONE_HOUR,
+      crimes: result.crimes,
+    });
+    ctx.response.body = { crimes: crimesByDate };
+  } catch (e) {
+    ctx.throw(400);
+  }
+};

--- a/src/routes/stats/router.ts
+++ b/src/routes/stats/router.ts
@@ -8,6 +8,7 @@ export default async (): Promise<Record<string, unknown>> => {
 
   //   get
   router.get('/stats', controller.getStats);
+  router.get('/stats/issue/:issueId/crimes/count', controller.getCrimesCount);
 
   return router;
 };

--- a/src/routes/stats/services/crimesCount.ts
+++ b/src/routes/stats/services/crimesCount.ts
@@ -1,0 +1,84 @@
+import { Types } from 'mongoose';
+
+interface IGetCrimesCountAggregateParams {
+  start: Date;
+  end: Date;
+  interval: number;
+  issueId: string;
+}
+
+export const getCrimesCountAggregate = (
+  params: IGetCrimesCountAggregateParams,
+): Record<string, unknown>[] => {
+  const { start, end, interval, issueId } = params;
+  return [
+    { $match: { _id: Types.ObjectId(issueId) } },
+    {
+      $lookup: {
+        from: 'crimes',
+        let: { crimes: '$crimeIds' },
+        pipeline: [
+          {
+            $match: {
+              $and: [
+                { $expr: { $in: ['$_id', '$$crimes'] } },
+                { occuredAt: { $gte: start, $lte: end } },
+              ],
+            },
+          },
+          {
+            $group: {
+              _id: {
+                $subtract: [
+                  { $subtract: ['$occuredAt', new Date('1970-01-01')] },
+                  {
+                    $mod: [{ $subtract: ['$occuredAt', new Date('1970-01-01')] }, interval],
+                  },
+                ],
+              },
+              count: { $sum: 1 },
+            },
+          },
+        ],
+        as: 'crimes',
+      },
+    },
+    { $project: { _id: 0, crimes: 1 } },
+  ];
+};
+
+interface ISetDefaultGroupParams {
+  start: Date;
+  interval: number;
+  crimes: { _id: number; count: number }[];
+}
+
+// 분,초의 ms를 빼줌 (ex: 167143230000 - 230000)
+const getMillsecondsHour = (start: Date) => {
+  const startMillseconds = start.getTime();
+  const [MILLSECONDS_MINUTES, MILLSECONDS_SECONDS] = [1000 * 60, 1000];
+  const startHourMillseconds =
+    startMillseconds -
+    (start.getMinutes() * MILLSECONDS_MINUTES +
+      start.getSeconds() * MILLSECONDS_SECONDS +
+      start.getMilliseconds());
+  return startHourMillseconds;
+};
+
+export const setDefaultGroup = (
+  params: ISetDefaultGroupParams,
+): { _id: number; count: number }[] => {
+  const { start, crimes, interval } = params;
+  const startMsOfHour = getMillsecondsHour(start);
+  const date: number[] = Array(24)
+    .fill(0)
+    .map((_, i) => {
+      return startMsOfHour + i * interval;
+    });
+  const crimesCountByDate = date.map((time) => {
+    const crimeIndex = crimes.findIndex((crime) => crime._id === time);
+    if (crimeIndex >= 0) return { _id: time, count: crimes[crimeIndex].count };
+    return { _id: time, count: 0 };
+  });
+  return crimesCountByDate;
+};


### PR DESCRIPTION
### 구현의도
- 에러 리스트, 에러 디테일 페이지에서 24시간 기준 에러 빈도 그래프 데이터를 위한 api 추가

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
