### PR TITLE
Issuecount 라우터 추가

### DIFF
--- a/src/routes/stats/controllers/getIssueCount.ts
+++ b/src/routes/stats/controllers/getIssueCount.ts
@@ -1,0 +1,50 @@
+import { Context, Next } from 'koa';
+import { Types } from 'mongoose';
+import Issue, { IIssueDocument } from '../../../models/Issue';
+
+export default async (ctx: Context, next: Next): Promise<void> => {
+  let { projectId } = ctx.query;
+  if (!Array.isArray(projectId)) {
+    projectId = [projectId];
+  }
+  projectId = projectId.map((id: string) => {
+    return Types.ObjectId(id);
+  });
+
+  const result: IIssueDocument[] = await Issue.aggregate([
+    { $match: { projectId: { $in: projectId } } },
+    {
+      $lookup: {
+        localField: 'crimeIds',
+        from: 'crimes',
+        foreignField: '_id',
+        as: 'totalCrime',
+      },
+    },
+
+    { $unwind: '$totalCrime' },
+
+    {
+      $group: {
+        _id: { _id: '$_id', message: '$message', type: '$type' },
+        crimeIds: { $addToSet: '$crimeIds' },
+        users: { $addToSet: '$totalCrime.meta.ip' },
+      },
+    },
+    { $unwind: '$crimeIds' },
+    {
+      $group: {
+        _id: '$_id._id',
+        message: { $addToSet: '$_id.message' },
+        type: { $addToSet: '$_id.type' },
+        crimeCount: { $sum: { $size: '$crimeIds' } },
+        userCount: { $sum: { $size: '$users' } },
+      },
+    },
+    { $unwind: '$type' },
+    { $unwind: '$message' },
+  ]);
+  ctx.body = result;
+
+  await next();
+};

--- a/src/routes/stats/router.ts
+++ b/src/routes/stats/router.ts
@@ -11,5 +11,6 @@ export default async (): Promise<Record<string, unknown>> => {
   router.get('/stats', controller.getStats);
   router.get('/stats/issue/:issueId/crimes/count', controller.getCrimesCount);
 
+  router.get('/countbyissue', controller.getIssueCount);
   return router;
 };


### PR DESCRIPTION

### 구현의도
- 이슈별 빈도,유저 그래프를 위한 api 추가


### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- user count, crime count 별 필터링이 추가되어야합니다.