### PR TITLE
sdk init시 api 요청 처리, 일별, 월별 방문자 api 생성 

### DIFF
--- a/src/models/Visits.ts
+++ b/src/models/Visits.ts
@@ -1,6 +1,7 @@
-import { Schema, Document, model, Model } from 'mongoose';
+import { Schema, Document, model, Model, Types } from 'mongoose';
 
 export interface IVisits {
+  projectId: string;
   ip: string;
   date: Date;
 }
@@ -8,15 +9,16 @@ export interface IVisits {
 export interface IVisitsDocument extends IVisits, Document {}
 
 export interface IVisitsModel extends Model<IVisitsDocument> {
-  build(ip: string, date: Date): IVisitsDocument;
+  build(attr: IVisits): IVisitsDocument;
 }
 
 const visitsSchema = new Schema({
+  projectId: { type: Types.ObjectId, required: true },
   ip: { type: String, required: true },
   date: { type: Date, required: true },
 });
 
-visitsSchema.statics.build = function buildVisits(visits: IVisits) {
+visitsSchema.statics.build = function buildVisits(visits: IVisits): IVisitsDocument {
   return new this(visits);
 };
 

--- a/src/models/Visits.ts
+++ b/src/models/Visits.ts
@@ -1,0 +1,24 @@
+import { Schema, Document, model, Model } from 'mongoose';
+
+export interface IVisits {
+  ip: string;
+  date: Date;
+}
+
+export interface IVisitsDocument extends IVisits, Document {}
+
+export interface IVisitsModel extends Model<IVisitsDocument> {
+  build(ip: string, date: Date): IVisitsDocument;
+}
+
+const visitsSchema = new Schema({
+  ip: { type: String, required: true },
+  date: { type: Date, required: true },
+});
+
+visitsSchema.statics.build = function buildVisits(visits: IVisits) {
+  return new this(visits);
+};
+
+const Visits = model<IVisitsDocument, IVisitsModel>('Visits', visitsSchema);
+export default Visits;

--- a/src/routes/crime/controllers/addVisits.ts
+++ b/src/routes/crime/controllers/addVisits.ts
@@ -1,0 +1,19 @@
+import { Context } from 'koa';
+import Visits, { IVisitsDocument } from '../../../models/Visits';
+
+interface IParams {
+  projectId: string;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { projectId }: IParams = ctx.params;
+  const { ip } = ctx.request;
+  const date = new Date(Date.now());
+  try {
+    const newVisitsDoc: IVisitsDocument = Visits.build({ projectId, ip, date });
+    await newVisitsDoc.save();
+    ctx.response.status = 200;
+  } catch (e) {
+    ctx.throw(400, 'internal error');
+  }
+};

--- a/src/routes/crime/controllers/addVisits.ts
+++ b/src/routes/crime/controllers/addVisits.ts
@@ -8,8 +8,14 @@ interface IParams {
 export default async (ctx: Context): Promise<void> => {
   const { projectId }: IParams = ctx.params;
   const { ip } = ctx.request;
-  const date = new Date(Date.now());
+  const today = new Date();
+  const date = new Date(today.getFullYear(), today.getMonth(), today.getDate());
   try {
+    const visited = await Visits.findOne({ projectId, ip, date });
+    if (visited !== null) {
+      ctx.response.status = 200;
+      return;
+    }
     const newVisitsDoc: IVisitsDocument = Visits.build({ projectId, ip, date });
     await newVisitsDoc.save();
     ctx.response.status = 200;

--- a/src/routes/crime/controllers/getMonthVisits.ts
+++ b/src/routes/crime/controllers/getMonthVisits.ts
@@ -1,0 +1,42 @@
+import { Context } from 'koa';
+import { Types } from 'mongoose';
+import Visits from '../../../models/Visits';
+
+interface IParams {
+  projectId: string;
+}
+interface IQuery {
+  year: number;
+  month: number;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { projectId }: IParams = ctx.params;
+  const { year, month }: IQuery = ctx.query;
+
+  const startDate = new Date(year, month - 1, 1);
+  const endDate = new Date(year, month, 0);
+  const visitsByDate = await Visits.aggregate([
+    {
+      $match: {
+        $and: [
+          { projectId: Types.ObjectId(projectId) },
+          { date: { $gte: startDate, $lte: endDate } },
+        ],
+      },
+    },
+    {
+      $group: {
+        _id: {
+          year: { $year: '$date' },
+          month: { $month: '$date' },
+          day: { $dayOfMonth: '$date' },
+        },
+        count: { $sum: 1 },
+      },
+    },
+    { $sort: { '_id.day': 1 } },
+  ]);
+
+  ctx.response.body = visitsByDate;
+};

--- a/src/routes/crime/controllers/getYearVisits.ts
+++ b/src/routes/crime/controllers/getYearVisits.ts
@@ -30,6 +30,15 @@ export default async (ctx: Context): Promise<void> => {
         _id: {
           year: { $year: '$date' },
           month: { $month: '$date' },
+          ip: '$ip',
+        },
+      },
+    },
+    {
+      $group: {
+        _id: {
+          year: '$_id.year',
+          month: '$_id.month',
         },
         count: { $sum: 1 },
       },

--- a/src/routes/crime/controllers/getYearVisits.ts
+++ b/src/routes/crime/controllers/getYearVisits.ts
@@ -1,0 +1,40 @@
+import { Context } from 'koa';
+import { Types } from 'mongoose';
+import Visits from '../../../models/Visits';
+
+interface IParams {
+  projectId: string;
+}
+
+interface IQuery {
+  year: number;
+}
+
+export default async (ctx: Context): Promise<void> => {
+  const { projectId }: IParams = ctx.params;
+  const { year }: IQuery = ctx.query;
+
+  const startDate = new Date(year, 0, 1);
+  const endDate = new Date(year, 12, 0);
+  const visitsByMonth = await Visits.aggregate([
+    {
+      $match: {
+        $and: [
+          { projectId: Types.ObjectId(projectId) },
+          { date: { $gte: startDate, $lte: endDate } },
+        ],
+      },
+    },
+    {
+      $group: {
+        _id: {
+          year: { $year: '$date' },
+          month: { $month: '$date' },
+        },
+        count: { $sum: 1 },
+      },
+    },
+    { $sort: { '_id.month': 1 } },
+  ]);
+  ctx.response.body = visitsByMonth;
+};

--- a/src/routes/crime/router.ts
+++ b/src/routes/crime/router.ts
@@ -9,6 +9,8 @@ export default async (): Promise<Record<string, unknown>> => {
   // get
   router.get('/crimes/:issueId', controller.getCrimes);
   router.get('/crime/:crimeId', controller.getCrime);
+  router.get('/crime/:projectId/visits/month', controller.getMonthVisits);
+  router.get('/crime/:projectId/visits/year', controller.getYearVisits);
 
   // post
   router.post('/crime/:projectId', controller.addCrime);

--- a/src/routes/crime/router.ts
+++ b/src/routes/crime/router.ts
@@ -12,6 +12,7 @@ export default async (): Promise<Record<string, unknown>> => {
 
   // post
   router.post('/crime/:projectId', controller.addCrime);
+  router.post('/crime/:projectId/visits', controller.addVisits);
 
   /**
    * @WARNING


### PR DESCRIPTION
### 구현의도
- visits 모델 생성
   projectId, ip, date를 저장

- sdk init시 api 요청 처리
  projectid와 ip, date가 같으면 삽입하지 않도록 구현
  
- 일별, 월별 방문자 api 생성 
  연, 월을 받아 일별 방문자를 반환하는 api
  연도를 받아 월별 방문자를 반환하는 api

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
