### PR TITLE
이슈 디테일에서 사용할 메타 정보 Count API

### DIFF
--- a/src/routes/stats/controllers/getCrimesCount.ts
+++ b/src/routes/stats/controllers/getCrimesCount.ts
@@ -1,26 +1,32 @@
 import { Context } from 'koa';
-import { getCrimesCountAggregate, setDefaultGroup } from '../services/crimesCount';
+import {
+  getCrimesCountAggregate,
+  setDefaultGroup,
+  getDateByInterval,
+} from '../services/crimesCount';
 import Issue from '../../../models/Issue';
-
-const MILLISECOND_OF_TWELVE_HOUR = 3600 * 24 * 1000;
 
 interface IParams {
   issueId: string;
 }
 
+interface IQuery {
+  intervalType: string;
+}
+
 export default async (ctx: Context): Promise<void> => {
   const { issueId }: IParams = ctx.params;
-  const start = new Date(Date.now() - MILLISECOND_OF_TWELVE_HOUR);
-  const end = new Date(Date.now());
-  const INTERVAL_ONE_HOUR = 60 * 1000 * 60;
+  const { intervalType }: IQuery = ctx.query;
+  const { start, end, interval } = getDateByInterval(intervalType);
   try {
     const [result] = await Issue.aggregate(
-      getCrimesCountAggregate({ issueId, start, end, interval: INTERVAL_ONE_HOUR }),
+      getCrimesCountAggregate({ issueId, start, end, interval }),
     );
     const crimesByDate = setDefaultGroup({
       start,
-      interval: INTERVAL_ONE_HOUR,
+      interval,
       crimes: result.crimes,
+      intervalType,
     });
     ctx.response.body = { crimes: crimesByDate };
   } catch (e) {

--- a/src/routes/stats/controllers/getSharesByIssue.ts
+++ b/src/routes/stats/controllers/getSharesByIssue.ts
@@ -1,0 +1,62 @@
+import { Types } from 'mongoose';
+import { Context } from 'koa';
+import Issue from '../../../models/Issue';
+
+export default async (ctx: Context): Promise<void> => {
+  const { issueId } = ctx.params;
+  try {
+    const [result] = await Issue.aggregate([
+      { $match: { _id: Types.ObjectId(issueId) } },
+      {
+        $lookup: {
+          from: 'crimes',
+          let: { crimes: '$crimeIds' },
+          pipeline: [
+            { $match: { $expr: { $in: ['$_id', '$$crimes'] } } },
+            {
+              $facet: {
+                browser: [
+                  {
+                    $group: {
+                      _id: '$meta.browser.name',
+                      count: { $sum: 1 },
+                    },
+                  },
+                  { $project: { _id: 0, name: '$_id', count: 1 } },
+                  { $sort: { count: -1 } },
+                ],
+                os: [
+                  {
+                    $group: {
+                      _id: '$meta.os.name',
+                      count: { $sum: 1 },
+                    },
+                  },
+                  { $project: { _id: 0, name: '$_id', count: 1 } },
+                  { $sort: { count: -1 } },
+                ],
+                url: [
+                  {
+                    $group: {
+                      _id: '$meta.url',
+                      count: { $sum: 1 },
+                    },
+                  },
+                  { $project: { _id: 0, name: '$_id', count: 1 } },
+                  { $sort: { count: -1 } },
+                ],
+              },
+            },
+          ],
+          as: 'metas',
+        },
+      },
+      { $unwind: '$metas' },
+      { $project: { metas: 1 } },
+    ]);
+    ctx.body = result;
+  } catch (e) {
+    console.log(e);
+    ctx.throw(500);
+  }
+};

--- a/src/routes/stats/controllers/getSharesByIssue.ts
+++ b/src/routes/stats/controllers/getSharesByIssue.ts
@@ -24,6 +24,7 @@ export default async (ctx: Context): Promise<void> => {
                   },
                   { $project: { _id: 0, name: '$_id', count: 1 } },
                   { $sort: { count: -1 } },
+                  { $limit: 7 },
                 ],
                 os: [
                   {
@@ -34,6 +35,7 @@ export default async (ctx: Context): Promise<void> => {
                   },
                   { $project: { _id: 0, name: '$_id', count: 1 } },
                   { $sort: { count: -1 } },
+                  { $limit: 7 },
                 ],
                 url: [
                   {
@@ -44,6 +46,7 @@ export default async (ctx: Context): Promise<void> => {
                   },
                   { $project: { _id: 0, name: '$_id', count: 1 } },
                   { $sort: { count: -1 } },
+                  { $limit: 7 },
                 ],
               },
             },
@@ -56,7 +59,6 @@ export default async (ctx: Context): Promise<void> => {
     ]);
     ctx.body = result;
   } catch (e) {
-    console.log(e);
     ctx.throw(500);
   }
 };

--- a/src/routes/stats/router.ts
+++ b/src/routes/stats/router.ts
@@ -11,6 +11,7 @@ export default async (): Promise<Record<string, unknown>> => {
   router.get('/stats/shares', controller.getShares);
   router.get('/stats/interval', controller.getCountByInterval);
   router.get('/stats', controller.getStats);
+  router.get('/stats/issue/:issueId/shares', controller.getSharesByIssue);
 
   router.get('/countbyissue', controller.getIssueCount);
   router.get('/session', controller.getSession);

--- a/src/routes/stats/services/crimesCount.ts
+++ b/src/routes/stats/services/crimesCount.ts
@@ -114,7 +114,7 @@ export const getDateByInterval = (
 ): { start: Date; end: Date; interval: number } => {
   const end = new Date();
   if (intervalType === IntervalType.HOUR) {
-    const MILLISECOND_OF_TWELVE_HOUR = 3600 * 24 * 1000;
+    const MILLISECOND_OF_TWELVE_HOUR = 3600 * 23 * 1000;
     const start = new Date(end.getTime() - MILLISECOND_OF_TWELVE_HOUR);
     const INTERVAL_ONE_HOUR = 60 * 1000 * 60;
     return { start, end, interval: INTERVAL_ONE_HOUR };


### PR DESCRIPTION
### 구현의도
- 메타 정보들(browser, os, url)에 대해서 count 구하고 보내는 API
- getCrimesCount에 대한 수정 -> 타입을 지정해 24시간, 30일에 대한 crime의 count를 가져올 수 있게 함.

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
