### PR TITLE
이슈리스트 정렬 오류 

### DIFF
--- a/src/routes/stats/controllers/getSession.ts
+++ b/src/routes/stats/controllers/getSession.ts
@@ -53,6 +53,7 @@ export default async (ctx: Context): Promise<void> => {
             hour: { $hour: { $toDate: '$sessions.sessionBase' } },
           },
           avg_duration: { $avg: '$sessions.duration' },
+          sum_duration: { $sum: '$sessions.duration' },
           count: { $sum: 1 },
         },
       },
@@ -62,6 +63,7 @@ export default async (ctx: Context): Promise<void> => {
     const perDay = await Project.aggregate([
       { $match: { _id: { $in: projectId } } },
       { $unwind: '$sessions' },
+
       {
         $group: {
           _id: {
@@ -70,10 +72,26 @@ export default async (ctx: Context): Promise<void> => {
             day: { $dayOfMonth: { $toDate: '$sessions.sessionBase' } },
           },
           avg_duration: { $avg: '$sessions.duration' },
+          sum_duration: { $sum: '$sessions.duration' },
           count: { $sum: 1 },
         },
       },
-      { $sort: { count: -1 } },
+      {
+        $addFields: {
+          base: {
+            $toDate: {
+              $concat: [
+                { $toString: '$_id.year' },
+                '-',
+                { $toString: '$_id.month' },
+                '-',
+                { $toString: '$_id.day' },
+              ],
+            },
+          },
+        },
+      },
+      { $sort: { base: -1 } },
     ]);
 
     const perMonth = await Project.aggregate([
@@ -86,6 +104,7 @@ export default async (ctx: Context): Promise<void> => {
             month: { $month: { $toDate: '$sessions.sessionBase' } },
           },
           avg_duration: { $avg: '$sessions.duration' },
+          sum_duration: { $sum: '$sessions.duration' },
           count: { $sum: 1 },
         },
       },


### PR DESCRIPTION
### 구현의도
- issueList API의 정렬 오류를 해결했습니다.
- 마지막 crime기준으로 정렬한 데이터를 반환합니다.
- getSession API 정렬기준을 날짜 기준으로 변경했습니다. 

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 이벤트 시간에 의해서 정렬해 두었는데 이벤트 시간이 겹치는 경우가 있어서 추후 수정 pr 올라갈 예정입니다.
