### PR TITLE
crime에 커스톰 태그 들어가도록 수정

### DIFF
--- a/src/models/Crime.ts
+++ b/src/models/Crime.ts
@@ -24,41 +24,45 @@ export interface ICrime {
   };
 }
 
-export interface ICrimeDocument extends ICrime, Document {}
+// eslint-disable-next-line prettier/prettier
+export interface ICrimeDocument extends ICrime, Document { }
 export interface ICrimeModel extends Model<ICrimeDocument> {
   build(attr: ICrime): ICrimeDocument;
 }
 
-const CrimeSchema = new Schema({
-  message: { type: String, required: true },
-  type: { type: String, required: true },
-  stack: [
-    {
-      columnNo: { type: String, required: true },
-      lineNo: { type: String, required: true },
-      function: { type: String, required: true },
-      filename: { type: String, required: true },
-    },
-  ],
-  occuredAt: { type: Date, required: true },
-  projectId: { type: String, require: true },
-  sdk: {
-    name: { type: String, required: true },
-    version: { type: String, required: true },
-  },
-  meta: {
-    browser: {
+const CrimeSchema = new Schema(
+  {
+    message: { type: String, required: true },
+    type: { type: String, required: true },
+    stack: [
+      {
+        columnNo: { type: String, required: true },
+        lineNo: { type: String, required: true },
+        function: { type: String, required: true },
+        filename: { type: String, required: true },
+      },
+    ],
+    occuredAt: { type: Date, required: true },
+    projectId: { type: String, require: true },
+    sdk: {
       name: { type: String, required: true },
       version: { type: String, required: true },
     },
-    os: {
-      name: { type: String, required: true },
-      version: { type: String, required: true },
+    meta: {
+      browser: {
+        name: { type: String, required: true },
+        version: { type: String, required: true },
+      },
+      os: {
+        name: { type: String, required: true },
+        version: { type: String, required: true },
+      },
+      url: { type: String, required: true },
+      ip: { type: String, required: true },
     },
-    url: { type: String, required: true },
-    ip: { type: String, required: true },
   },
-});
+  { strict: false },
+);
 
 CrimeSchema.statics.build = function buildCrime(Crime: ICrime): ICrimeDocument {
   return new this(Crime);


### PR DESCRIPTION
### 구현의도
- crime 스키마에 strict 모드가 걸려있어서 기존의 커스톰 태그를 받지 못하고있었습니다.
- 이를 해제하여 meta.key=value 형태로 커스톰 태그를 저장하도록 했습니다.

