### PR TITLE
Crimes 추가 api (캐싱)

### DIFF
--- a/src/routes/sdk/controllers/addCrime.ts
+++ b/src/routes/sdk/controllers/addCrime.ts
@@ -1,33 +1,14 @@
 import { Context, Next } from 'koa';
-import { Types } from 'mongoose';
-import Crime, { ICrime, ICrimeDocument } from '../../../models/Crime';
-import Issue from '../../../models/Issue';
-// message, stack, type이 같은 경우 동일 에러 종류로 분류
-// project
+import { ICrime } from '../../../models/Crime';
+import addCrime from '../services/addCrime';
+
 export default async (ctx: Context, next: Next): Promise<void> => {
   const newCrime: ICrime = ctx.request.body;
   const { projectId } = ctx.params;
   newCrime.projectId = projectId;
   newCrime.meta.ip = ctx.request.ip;
   try {
-    const newCrimeDoc: ICrimeDocument = Crime.build(newCrime);
-    const res = await newCrimeDoc.save();
-    await Issue.findOneAndUpdate(
-      {
-        projectId: Types.ObjectId(projectId),
-        message: newCrime.message,
-        stack: newCrime.stack,
-        type: newCrime.type,
-        isOpen: true,
-      },
-      {
-        $push: { crimeIds: res._id },
-      },
-      {
-        new: true,
-        upsert: true,
-      },
-    );
+    await addCrime(newCrime, projectId);
     ctx.response.status = 200;
   } catch (e) {
     ctx.throw(400, 'validation failed');

--- a/src/routes/sdk/controllers/addCrimes.ts
+++ b/src/routes/sdk/controllers/addCrimes.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-param-reassign */
+import { Context, Next } from 'koa';
+import { Types } from 'mongoose';
+import Crime, { ICrime, ICrimeDocument } from '../../../models/Crime';
+import Issue from '../../../models/Issue';
+
+export default async (ctx: Context, next: Next): Promise<void> => {
+  const newCrimes: ICrime[] = ctx.request.body;
+  const { projectId } = ctx.params;
+  const userIp = ctx.request.ip;
+  newCrimes.map((newCrime) => {
+    newCrime.projectId = projectId;
+    newCrime.meta.ip = userIp;
+  });
+  try {
+    await Promise.all(
+      newCrimes.map(async (newCrime) => {
+        const newCrimeDoc: ICrimeDocument = Crime.build(newCrime);
+        const res = await newCrimeDoc.save();
+        await Issue.findOneAndUpdate(
+          {
+            projectId: Types.ObjectId(projectId),
+            message: newCrime.message,
+            stack: newCrime.stack,
+            type: newCrime.type,
+            isOpen: true,
+          },
+          {
+            $push: { crimeIds: res._id },
+          },
+          {
+            new: true,
+            upsert: true,
+          },
+        );
+      }),
+    );
+    ctx.response.status = 200;
+  } catch (e) {
+    ctx.throw(400, 'validation failed');
+  }
+
+  await next();
+};

--- a/src/routes/sdk/controllers/addCrimes.ts
+++ b/src/routes/sdk/controllers/addCrimes.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Context, Next } from 'koa';
-import { Types } from 'mongoose';
-import Crime, { ICrime, ICrimeDocument } from '../../../models/Crime';
-import Issue from '../../../models/Issue';
+import { ICrime } from '../../../models/Crime';
+import addCrime from '../services/addCrime';
 
 export default async (ctx: Context, next: Next): Promise<void> => {
   const newCrimes: ICrime[] = ctx.request.body;
@@ -15,24 +14,7 @@ export default async (ctx: Context, next: Next): Promise<void> => {
   try {
     await Promise.all(
       newCrimes.map(async (newCrime) => {
-        const newCrimeDoc: ICrimeDocument = Crime.build(newCrime);
-        const res = await newCrimeDoc.save();
-        await Issue.findOneAndUpdate(
-          {
-            projectId: Types.ObjectId(projectId),
-            message: newCrime.message,
-            stack: newCrime.stack,
-            type: newCrime.type,
-            isOpen: true,
-          },
-          {
-            $push: { crimeIds: res._id },
-          },
-          {
-            new: true,
-            upsert: true,
-          },
-        );
+        await addCrime(newCrime, projectId);
       }),
     );
     ctx.response.status = 200;

--- a/src/routes/sdk/router.ts
+++ b/src/routes/sdk/router.ts
@@ -9,6 +9,7 @@ export default async (): Promise<Record<string, unknown>> => {
   // post
   router.post('/sdk/:projectId/visits', controller.addVisits);
   router.post('/sdk/:projectId/crime', controller.addCrime);
+  router.post('/sdk/:projectId/crimes', controller.addCrimes);
 
   router.post('/sdk/:projectId/session', controller.addSession);
   return router;

--- a/src/routes/sdk/services/addCrime.ts
+++ b/src/routes/sdk/services/addCrime.ts
@@ -1,0 +1,25 @@
+import { Types } from 'mongoose';
+import Crime, { ICrime, ICrimeDocument } from '../../../models/Crime';
+import Issue from '../../../models/Issue';
+
+const addCrime = async (newCrime: ICrime, projectId: string): Promise<void> => {
+  const newCrimeDoc: ICrimeDocument = Crime.build(newCrime);
+  const res = await newCrimeDoc.save();
+  await Issue.findOneAndUpdate(
+    {
+      projectId: Types.ObjectId(projectId),
+      message: newCrime.message,
+      stack: newCrime.stack,
+      type: newCrime.type,
+      isOpen: true,
+    },
+    {
+      $push: { crimeIds: res._id },
+    },
+    {
+      new: true,
+      upsert: true,
+    },
+  );
+};
+export default addCrime;


### PR DESCRIPTION
### 구현의도
- Crimes 추가 api
  crime마다 project id, ip를 추가하고 기존 crime 추가하는 로직을 반복문으로 처리
  프로젝트마다 issue 분류 작업을 해줘야 하기 때문에 로직을 반복문으로 결정

- crime 추가 로직을 service 계층으로 분리

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
