### PR TITLE
project / user 삭제 api 수정, controller 전체 리팩토링, error handling

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,16 +22,16 @@ app.use(cors());
 if (process.env.NODE_ENV === 'development') app.use(logger());
 app.use(apiRouter().routes());
 
-/**
- * @TODO
- * 에러 코드 분리
- */
 app.on('error', (err, ctx) => {
-  // 에러 코드
-  console.log(err.status);
-  // 에러 메시지
-  console.log(err.message);
-  // console.log('server error', err, ctx);
+  if (err.status === 400) {
+    ctx.status = 400;
+    return;
+  }
+  if (err.status === 401) {
+    ctx.status = 401;
+    return;
+  }
+  ctx.status = 500;
 });
 
 app.listen(PORT, () => {

--- a/src/routes/crime/controllers/getCrime.ts
+++ b/src/routes/crime/controllers/getCrime.ts
@@ -14,6 +14,6 @@ export default async (ctx: Context): Promise<void> => {
     if (result === null) ctx.throw(400);
     ctx.response.body = result;
   } catch (e) {
-    ctx.throw(500);
+    ctx.throw(400);
   }
 };

--- a/src/routes/crime/controllers/getCrimes.ts
+++ b/src/routes/crime/controllers/getCrimes.ts
@@ -2,7 +2,7 @@ import { Context } from 'koa';
 import { Types } from 'mongoose';
 import Issue from '../../../models/Issue';
 
-const CONTENT_PER_PAGE = 5;
+const CONTENT_PER_PAGE = 10;
 
 interface IParams {
   issueId: string;

--- a/src/routes/crime/controllers/getMonthVisits.ts
+++ b/src/routes/crime/controllers/getMonthVisits.ts
@@ -13,30 +13,33 @@ interface IQuery {
 export default async (ctx: Context): Promise<void> => {
   const { projectId }: IParams = ctx.params;
   const { year, month }: IQuery = ctx.query;
-
-  const startDate = new Date(year, month - 1, 1);
-  const endDate = new Date(year, month, 0);
-  const visitsByDate = await Visits.aggregate([
-    {
-      $match: {
-        $and: [
-          { projectId: Types.ObjectId(projectId) },
-          { date: { $gte: startDate, $lte: endDate } },
-        ],
-      },
-    },
-    {
-      $group: {
-        _id: {
-          year: { $year: '$date' },
-          month: { $month: '$date' },
-          day: { $dayOfMonth: '$date' },
+  try {
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 0);
+    const visitsByDate = await Visits.aggregate([
+      {
+        $match: {
+          $and: [
+            { projectId: Types.ObjectId(projectId) },
+            { date: { $gte: startDate, $lte: endDate } },
+          ],
         },
-        count: { $sum: 1 },
       },
-    },
-    { $sort: { '_id.day': 1 } },
-  ]);
+      {
+        $group: {
+          _id: {
+            year: { $year: '$date' },
+            month: { $month: '$date' },
+            day: { $dayOfMonth: '$date' },
+          },
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { '_id.day': 1 } },
+    ]);
 
-  ctx.response.body = visitsByDate;
+    ctx.response.body = visitsByDate;
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/crime/controllers/getYearVisits.ts
+++ b/src/routes/crime/controllers/getYearVisits.ts
@@ -13,37 +13,40 @@ interface IQuery {
 export default async (ctx: Context): Promise<void> => {
   const { projectId }: IParams = ctx.params;
   const { year }: IQuery = ctx.query;
-
-  const startDate = new Date(year, 0, 1);
-  const endDate = new Date(year, 12, 0);
-  const visitsByMonth = await Visits.aggregate([
-    {
-      $match: {
-        $and: [
-          { projectId: Types.ObjectId(projectId) },
-          { date: { $gte: startDate, $lte: endDate } },
-        ],
-      },
-    },
-    {
-      $group: {
-        _id: {
-          year: { $year: '$date' },
-          month: { $month: '$date' },
-          ip: '$ip',
+  try {
+    const startDate = new Date(year, 0, 1);
+    const endDate = new Date(year, 12, 0);
+    const visitsByMonth = await Visits.aggregate([
+      {
+        $match: {
+          $and: [
+            { projectId: Types.ObjectId(projectId) },
+            { date: { $gte: startDate, $lte: endDate } },
+          ],
         },
       },
-    },
-    {
-      $group: {
-        _id: {
-          year: '$_id.year',
-          month: '$_id.month',
+      {
+        $group: {
+          _id: {
+            year: { $year: '$date' },
+            month: { $month: '$date' },
+            ip: '$ip',
+          },
         },
-        count: { $sum: 1 },
       },
-    },
-    { $sort: { '_id.month': 1 } },
-  ]);
-  ctx.response.body = visitsByMonth;
+      {
+        $group: {
+          _id: {
+            year: '$_id.year',
+            month: '$_id.month',
+          },
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { '_id.month': 1 } },
+    ]);
+    ctx.response.body = visitsByMonth;
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/issue/controllers/getIssue.ts
+++ b/src/routes/issue/controllers/getIssue.ts
@@ -1,81 +1,12 @@
-import { Context, Next } from 'koa';
-import { Types } from 'mongoose';
-import Issue from '../../../models/Issue';
+import { Context } from 'koa';
+import getIssue from '../services/getIssue';
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const { issueId } = ctx.params;
-  const [result]: any[] = await Issue.aggregate([
-    { $match: { _id: Types.ObjectId(issueId) } },
-    { $addFields: { stack: { $arrayElemAt: ['$stack', 0] } } },
-    {
-      $lookup: {
-        from: 'projects',
-        let: { id: '$projectId' },
-        pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$id'] } } }, { $project: { name: 1 } }],
-
-        as: 'project',
-      },
-    },
-
-    { $addFields: { lastCrimeId: { $arrayElemAt: ['$crimeIds', -1] } } },
-    {
-      $lookup: {
-        localField: 'lastCrimeId',
-        from: 'crimes',
-        foreignField: '_id',
-        as: 'lastCrime',
-      },
-    },
-
-    { $unwind: '$lastCrime' },
-    {
-      $lookup: {
-        localField: 'crimeIds',
-        from: 'crimes',
-        foreignField: '_id',
-        as: 'totalCrime',
-      },
-    },
-    { $unwind: '$totalCrime' },
-
-    {
-      $group: {
-        _id: {
-          _id: '$_id',
-          type: '$type',
-          message: '$message',
-          stack: '$stack',
-          lastCrime: '$lastCrime',
-          project: '$project',
-        },
-        crimeIds: { $addToSet: '$crimeIds' },
-        users: { $addToSet: '$totalCrime.meta.ip' },
-      },
-    },
-    { $unwind: '$crimeIds' },
-    {
-      $group: {
-        _id: '$_id._id',
-        type: { $addToSet: '$_id.type' },
-        message: { $addToSet: '$_id.message' },
-        stack: { $addToSet: '$_id.stack' },
-        project: { $addToSet: '$_id.project' },
-        crimeIds: { $addToSet: '$crimeIds' },
-        lastCrime: { $addToSet: '$_id.lastCrime' },
-        crimeCount: { $sum: { $size: '$crimeIds' } },
-        userCount: { $sum: { $size: '$users' } },
-      },
-    },
-    { $unwind: '$type' },
-    { $unwind: '$message' },
-    { $unwind: '$stack' },
-    { $unwind: '$project' },
-    { $unwind: '$project' },
-    { $unwind: '$crimeIds' },
-    { $unwind: '$lastCrime' },
-    { $addFields: { occuredAt: { $toDate: '$lastCrime.occuredAt' } } },
-  ]);
-  ctx.body = result;
-
-  await next();
+  try {
+    const result: any = await getIssue(issueId);
+    ctx.body = result;
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/issue/controllers/getIssues.ts
+++ b/src/routes/issue/controllers/getIssues.ts
@@ -1,10 +1,9 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import { Types } from 'mongoose';
-import Issue, { IIssueDocument } from '../../../models/Issue';
+import { IIssueDocument } from '../../../models/Issue';
+import getIssues from '../services/getIssues';
 
-const CONTENT_PER_PAGE = 15;
-
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   let { projectId } = ctx.query;
   if (!Array.isArray(projectId)) {
     projectId = [projectId];
@@ -12,102 +11,11 @@ export default async (ctx: Context, next: Next): Promise<void> => {
   projectId = projectId.map((id: string) => {
     return Types.ObjectId(id);
   });
-
   const page: number = parseInt(ctx.query.page, 10) || 1;
-
-  const [result]: IIssueDocument[] = await Issue.aggregate([
-    { $match: { projectId: { $in: projectId } } },
-    { $addFields: { stack: { $arrayElemAt: ['$stack', 0] } } },
-    {
-      $lookup: {
-        from: 'projects',
-        let: { id: '$projectId' },
-        pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$id'] } } }, { $project: { name: 1 } }],
-
-        as: 'project',
-      },
-    },
-
-    { $addFields: { lastCrimeId: { $arrayElemAt: ['$crimeIds', -1] } } },
-    {
-      $lookup: {
-        localField: 'lastCrimeId',
-        from: 'crimes',
-        foreignField: '_id',
-        as: 'lastCrime',
-      },
-    },
-
-    { $unwind: '$lastCrime' },
-    {
-      $lookup: {
-        localField: 'crimeIds',
-        from: 'crimes',
-        foreignField: '_id',
-        as: 'totalCrime',
-      },
-    },
-    { $unwind: '$totalCrime' },
-
-    {
-      $group: {
-        _id: {
-          _id: '$_id',
-          type: '$type',
-          message: '$message',
-          stack: '$stack',
-          lastCrime: '$lastCrime',
-          project: '$project',
-        },
-        crimeIds: { $addToSet: '$crimeIds' },
-        users: { $addToSet: '$totalCrime.meta.ip' },
-      },
-    },
-    { $unwind: '$crimeIds' },
-    {
-      $group: {
-        _id: '$_id._id',
-        type: { $addToSet: '$_id.type' },
-        message: { $addToSet: '$_id.message' },
-        stack: { $addToSet: '$_id.stack' },
-        project: { $addToSet: '$_id.project' },
-        crimeIds: { $addToSet: '$crimeIds' },
-        lastCrime: { $addToSet: '$_id.lastCrime' },
-        crimeCount: { $sum: { $size: '$crimeIds' } },
-        userCount: { $sum: { $size: '$users' } },
-      },
-    },
-    { $unwind: '$type' },
-    { $unwind: '$message' },
-    { $unwind: '$stack' },
-    { $unwind: '$project' },
-    { $unwind: '$project' },
-    { $unwind: '$crimeIds' },
-    { $unwind: '$lastCrime' },
-    { $addFields: { occuredAt: { $toDate: '$lastCrime.occuredAt' } } },
-
-    {
-      $sort: {
-        occuredAt: -1,
-        crimeCount: 1,
-        userCount: 1,
-        _id: 1,
-      },
-    },
-    {
-      $facet: {
-        metaData: [
-          { $count: 'total' },
-          { $addFields: { totalPage: { $ceil: { $divide: ['$total', CONTENT_PER_PAGE] } } } },
-          { $addFields: { page } },
-          { $addFields: { countPerPage: CONTENT_PER_PAGE } },
-        ],
-        data: [{ $skip: (page - 1) * CONTENT_PER_PAGE }, { $limit: CONTENT_PER_PAGE }],
-      },
-    },
-    { $unwind: '$metaData' },
-  ]);
-  ctx.body = result;
-
-  await next();
+  try {
+    const result: IIssueDocument[] = await getIssues(projectId, page);
+    ctx.body = result;
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/issue/controllers/updateIssueIsOpen.ts
+++ b/src/routes/issue/controllers/updateIssueIsOpen.ts
@@ -1,10 +1,6 @@
 import { Context } from 'koa';
 import Issue from '../../../models/Issue';
 
-interface IQuery {
-  issueId: string;
-}
-
 interface IBody {
   ids: string[];
   isOpen: boolean;
@@ -14,8 +10,8 @@ export default async (ctx: Context): Promise<void> => {
   const { ids, isOpen }: IBody = ctx.request.body;
   try {
     await Issue.updateMany({ _id: { $in: ids } }, { $set: { isOpen } });
+    ctx.status = 200;
   } catch (e) {
-    ctx.throw(500, 'internal server error');
+    ctx.throw(400);
   }
-  ctx.status = 200;
 };

--- a/src/routes/issue/services/getIssue.ts
+++ b/src/routes/issue/services/getIssue.ts
@@ -1,0 +1,79 @@
+import { Types } from 'mongoose';
+import Issue from '../../../models/Issue';
+
+const getIssue = async (issueId: string): Promise<any> => {
+  const [result]: any[] = await Issue.aggregate([
+    { $match: { _id: Types.ObjectId(issueId) } },
+    { $addFields: { stack: { $arrayElemAt: ['$stack', 0] } } },
+    {
+      $lookup: {
+        from: 'projects',
+        let: { id: '$projectId' },
+        pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$id'] } } }, { $project: { name: 1 } }],
+
+        as: 'project',
+      },
+    },
+
+    { $addFields: { lastCrimeId: { $arrayElemAt: ['$crimeIds', -1] } } },
+    {
+      $lookup: {
+        localField: 'lastCrimeId',
+        from: 'crimes',
+        foreignField: '_id',
+        as: 'lastCrime',
+      },
+    },
+
+    { $unwind: '$lastCrime' },
+    {
+      $lookup: {
+        localField: 'crimeIds',
+        from: 'crimes',
+        foreignField: '_id',
+        as: 'totalCrime',
+      },
+    },
+    { $unwind: '$totalCrime' },
+
+    {
+      $group: {
+        _id: {
+          _id: '$_id',
+          type: '$type',
+          message: '$message',
+          stack: '$stack',
+          lastCrime: '$lastCrime',
+          project: '$project',
+        },
+        crimeIds: { $addToSet: '$crimeIds' },
+        users: { $addToSet: '$totalCrime.meta.ip' },
+      },
+    },
+    { $unwind: '$crimeIds' },
+    {
+      $group: {
+        _id: '$_id._id',
+        type: { $addToSet: '$_id.type' },
+        message: { $addToSet: '$_id.message' },
+        stack: { $addToSet: '$_id.stack' },
+        project: { $addToSet: '$_id.project' },
+        crimeIds: { $addToSet: '$crimeIds' },
+        lastCrime: { $addToSet: '$_id.lastCrime' },
+        crimeCount: { $sum: { $size: '$crimeIds' } },
+        userCount: { $sum: { $size: '$users' } },
+      },
+    },
+    { $unwind: '$type' },
+    { $unwind: '$message' },
+    { $unwind: '$stack' },
+    { $unwind: '$project' },
+    { $unwind: '$project' },
+    { $unwind: '$crimeIds' },
+    { $unwind: '$lastCrime' },
+    { $addFields: { occuredAt: { $toDate: '$lastCrime.occuredAt' } } },
+  ]);
+  return result;
+};
+
+export default getIssue;

--- a/src/routes/issue/services/getIssues.ts
+++ b/src/routes/issue/services/getIssues.ts
@@ -1,0 +1,101 @@
+import Issue, { IIssueDocument } from '../../../models/Issue';
+
+const CONTENT_PER_PAGE = 15;
+
+const getIssues = async (projectId: string, page: number): Promise<any> => {
+  const [result]: IIssueDocument[] = await Issue.aggregate([
+    { $match: { projectId: { $in: projectId } } },
+    { $addFields: { stack: { $arrayElemAt: ['$stack', 0] } } },
+    {
+      $lookup: {
+        from: 'projects',
+        let: { id: '$projectId' },
+        pipeline: [{ $match: { $expr: { $eq: ['$_id', '$$id'] } } }, { $project: { name: 1 } }],
+
+        as: 'project',
+      },
+    },
+
+    { $addFields: { lastCrimeId: { $arrayElemAt: ['$crimeIds', -1] } } },
+    {
+      $lookup: {
+        localField: 'lastCrimeId',
+        from: 'crimes',
+        foreignField: '_id',
+        as: 'lastCrime',
+      },
+    },
+
+    { $unwind: '$lastCrime' },
+    {
+      $lookup: {
+        localField: 'crimeIds',
+        from: 'crimes',
+        foreignField: '_id',
+        as: 'totalCrime',
+      },
+    },
+    { $unwind: '$totalCrime' },
+
+    {
+      $group: {
+        _id: {
+          _id: '$_id',
+          type: '$type',
+          message: '$message',
+          stack: '$stack',
+          lastCrime: '$lastCrime',
+          project: '$project',
+        },
+        crimeIds: { $addToSet: '$crimeIds' },
+        users: { $addToSet: '$totalCrime.meta.ip' },
+      },
+    },
+    { $unwind: '$crimeIds' },
+    {
+      $group: {
+        _id: '$_id._id',
+        type: { $addToSet: '$_id.type' },
+        message: { $addToSet: '$_id.message' },
+        stack: { $addToSet: '$_id.stack' },
+        project: { $addToSet: '$_id.project' },
+        crimeIds: { $addToSet: '$crimeIds' },
+        lastCrime: { $addToSet: '$_id.lastCrime' },
+        crimeCount: { $sum: { $size: '$crimeIds' } },
+        userCount: { $sum: { $size: '$users' } },
+      },
+    },
+    { $unwind: '$type' },
+    { $unwind: '$message' },
+    { $unwind: '$stack' },
+    { $unwind: '$project' },
+    { $unwind: '$project' },
+    { $unwind: '$crimeIds' },
+    { $unwind: '$lastCrime' },
+    { $addFields: { occuredAt: { $toDate: '$lastCrime.occuredAt' } } },
+
+    {
+      $sort: {
+        occuredAt: -1,
+        crimeCount: 1,
+        userCount: 1,
+        _id: 1,
+      },
+    },
+    {
+      $facet: {
+        metaData: [
+          { $count: 'total' },
+          { $addFields: { totalPage: { $ceil: { $divide: ['$total', CONTENT_PER_PAGE] } } } },
+          { $addFields: { page } },
+          { $addFields: { countPerPage: CONTENT_PER_PAGE } },
+        ],
+        data: [{ $skip: (page - 1) * CONTENT_PER_PAGE }, { $limit: CONTENT_PER_PAGE }],
+      },
+    },
+    { $unwind: '$metaData' },
+  ]);
+  return result;
+};
+
+export default getIssues;

--- a/src/routes/project/controllers/acceptInvite.ts
+++ b/src/routes/project/controllers/acceptInvite.ts
@@ -1,48 +1,40 @@
 import Mongoose from 'mongoose';
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import CryptoJS from 'crypto-js';
 import Invite from '../../../models/Invite';
 import Project from '../../../models/Project';
 import User, { IUserDocument } from '../../../models/User';
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const { key } = ctx.query;
   const decodeKey = decodeURIComponent(key);
 
-  const result = await Invite.findOne({ key: decodeKey, expire: { $lte: new Date().getTime() } });
-  if (result) {
-    const session = await Mongoose.startSession();
+  const session = await Mongoose.startSession();
+  try {
     session.startTransaction();
+    const result = await Invite.findOne({ key: decodeKey, expire: { $lte: new Date().getTime() } });
+    if (result === null) {
+      throw Error();
+    }
     const bytes = CryptoJS.AES.decrypt(result.key, process.env.INVITE_SECRET_KEY as string);
     const decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
     const project = await Project.findOne({ _id: decryptedData.projectId }, null, { session });
     const user = (await User.findOne({ _id: ctx.state.user._id }, null, {
       session,
     })) as IUserDocument;
-    if (!project) {
-      await session.abortTransaction();
-      session.endSession();
-      ctx.throw(404, 'project not found');
+    if (project === null) {
+      throw Error();
     }
-    try {
-      await project.addUser(ctx.state.user._id);
-      user.addProject(project._id);
-      await user.save();
-      await project.save();
-      await session.commitTransaction();
-      session.endSession();
-      ctx.response.status = 200;
-    } catch (e) {
-      await session.abortTransaction();
-      session.endSession();
-      ctx.throw(500);
-    }
-    /**
-     * @todo
-     * project에 맞는 issue로 redirect
-     */
-  } else {
-    ctx.throw(401, 'invite code expired');
+    await project.addUser(ctx.state.user._id);
+    user.addProject(project._id);
+    await user.save();
+    await project.save();
+    await session.commitTransaction();
+    session.endSession();
+    ctx.response.status = 200;
+  } catch (e) {
+    await session.abortTransaction();
+    session.endSession();
+    ctx.throw(400);
   }
-  await next();
 };

--- a/src/routes/project/controllers/addProject.ts
+++ b/src/routes/project/controllers/addProject.ts
@@ -11,22 +11,20 @@ interface IBody {
 export default async (ctx: Context): Promise<void> => {
   const req: IBody = ctx.request.body;
   const session = await Mongoose.startSession();
-  session.startTransaction();
-  const user: IUserDocument | null = await User.findOne({ _id: ctx.state.user._id }, null, {
-    session,
-  });
-  if (!user) {
-    await session.abortTransaction();
-    session.endSession();
-    ctx.throw(404, 'user not found');
-  }
-  const newProject: IProject = {
-    ...req,
-    owner: ctx.state.user._id,
-    users: [],
-    sessions: [],
-  };
   try {
+    session.startTransaction();
+    const user: IUserDocument | null = await User.findOne({ _id: ctx.state.user._id }, null, {
+      session,
+    });
+    if (user === null) {
+      throw Error();
+    }
+    const newProject: IProject = {
+      ...req,
+      owner: ctx.state.user._id,
+      users: [],
+      sessions: [],
+    };
     const newProjectDoc: IProjectDocument = Project.build(newProject, session);
     await newProjectDoc.save();
     user.addProject(newProjectDoc._id);

--- a/src/routes/project/controllers/addProject.ts
+++ b/src/routes/project/controllers/addProject.ts
@@ -36,6 +36,6 @@ export default async (ctx: Context): Promise<void> => {
   } catch (e) {
     await session.abortTransaction();
     session.endSession();
-    ctx.throw(400, 'validation failed');
+    ctx.throw(400);
   }
 };

--- a/src/routes/project/controllers/deleteProject.ts
+++ b/src/routes/project/controllers/deleteProject.ts
@@ -11,6 +11,6 @@ export default async (ctx: Context): Promise<void> => {
     await Project.update({ _id: projectId }, { isDeleted: true });
     ctx.status = 200;
   } catch (e) {
-    ctx.throw(400, 'internal server error');
+    ctx.throw(400);
   }
 };

--- a/src/routes/project/controllers/deleteProject.ts
+++ b/src/routes/project/controllers/deleteProject.ts
@@ -9,8 +9,8 @@ export default async (ctx: Context): Promise<void> => {
   const { id: projectId }: IQuery = ctx.params;
   try {
     await Project.update({ _id: projectId }, { isDeleted: true });
+    ctx.status = 200;
   } catch (e) {
     ctx.throw(400, 'internal server error');
   }
-  ctx.status = 200;
 };

--- a/src/routes/project/controllers/deleteProjectUsers.ts
+++ b/src/routes/project/controllers/deleteProjectUsers.ts
@@ -1,5 +1,7 @@
+import Mongoose from 'mongoose';
 import { Context } from 'koa';
 import Project from '../../../models/Project';
+import User from '../../../models/User';
 
 interface IQuery {
   id: string;
@@ -12,15 +14,29 @@ interface IBody {
 export default async (ctx: Context): Promise<void> => {
   const { id: projectId }: IQuery = ctx.params;
   const { userIds }: IBody = ctx.request.body;
+  const session = await Mongoose.startSession();
+  session.startTransaction();
   try {
-    const project = await Project.findOne({ _id: projectId });
+    const project = await Project.findOne({ _id: projectId }, null, { session });
+
+    await User.updateMany(
+      { _id: { $in: userIds } },
+      { $pull: { projects: projectId } },
+      {
+        session,
+      },
+    );
     if (project === null) {
       ctx.throw(500);
     }
-    project.deleteUsers(userIds);
-    project.save();
+    await project.deleteUsers(userIds);
+    await project.save();
+    await session.commitTransaction();
+    session.endSession();
     ctx.status = 200;
   } catch (e) {
+    await session.abortTransaction();
+    session.endSession();
     ctx.throw(400, 'internal server error');
   }
 };

--- a/src/routes/project/controllers/deleteProjectUsers.ts
+++ b/src/routes/project/controllers/deleteProjectUsers.ts
@@ -15,10 +15,9 @@ export default async (ctx: Context): Promise<void> => {
   const { id: projectId }: IQuery = ctx.params;
   const { userIds }: IBody = ctx.request.body;
   const session = await Mongoose.startSession();
-  session.startTransaction();
   try {
+    session.startTransaction();
     const project = await Project.findOne({ _id: projectId }, null, { session });
-
     await User.updateMany(
       { _id: { $in: userIds } },
       { $pull: { projects: projectId } },
@@ -27,7 +26,7 @@ export default async (ctx: Context): Promise<void> => {
       },
     );
     if (project === null) {
-      ctx.throw(500);
+      throw Error();
     }
     await project.deleteUsers(userIds);
     await project.save();
@@ -37,6 +36,6 @@ export default async (ctx: Context): Promise<void> => {
   } catch (e) {
     await session.abortTransaction();
     session.endSession();
-    ctx.throw(400, 'internal server error');
+    ctx.throw(400);
   }
 };

--- a/src/routes/project/controllers/getProject.ts
+++ b/src/routes/project/controllers/getProject.ts
@@ -19,6 +19,6 @@ export default async (ctx: Context): Promise<void> => {
     }
     ctx.body = project;
   } catch (e) {
-    ctx.throw(500);
+    ctx.throw(400);
   }
 };

--- a/src/routes/project/controllers/getProjects.ts
+++ b/src/routes/project/controllers/getProjects.ts
@@ -20,9 +20,11 @@ interface IState {
 export default async (ctx: Context): Promise<void> => {
   const { userType = UserEnum.ALL }: IQuery = ctx.query;
   const { user } = ctx.state as IState;
-  const userDocument = await User.findOne({ _id: user._id });
-  if (!userDocument) ctx.throw(404, 'user not found');
   try {
+    const userDocument = await User.findOne({ _id: user._id });
+    if (userDocument === null) {
+      throw Error();
+    }
     let projects = await Project.find({ isDeleted: { $ne: true } })
       .populate('owner')
       .populate('users')
@@ -39,6 +41,6 @@ export default async (ctx: Context): Promise<void> => {
     ctx.response.status = 200;
     ctx.body = { projects };
   } catch (e) {
-    ctx.throw(500);
+    ctx.throw(400);
   }
 };

--- a/src/routes/project/controllers/sendInvite.ts
+++ b/src/routes/project/controllers/sendInvite.ts
@@ -1,38 +1,41 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 
 import CryptoJS from 'crypto-js';
 import sendMail from '../../../utils/sendMail';
 import inviteMemberTemplate from '../../../utils/mailTemplate/inviteMember';
 import Invite, { InviteType, InviteDocument } from '../../../models/Invite';
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const { to, project, projectId } = ctx.request.body;
   const info: any[] = [];
-  await to.forEach(async (email: string) => {
-    const json = {
-      email,
-      projectId,
-    };
-    const ciphertext = CryptoJS.AES.encrypt(
-      JSON.stringify(json),
-      process.env.INVITE_SECRET_KEY as string,
-    ).toString();
-    const newInvite: InviteType = {
-      key: ciphertext,
-      expire: new Date().getTime() + 3600,
-    };
-    const newInviteDoc: InviteDocument = new Invite(newInvite);
-    await newInviteDoc.save();
+  try {
+    await to.forEach(async (email: string) => {
+      const json = {
+        email,
+        projectId,
+      };
+      const ciphertext = CryptoJS.AES.encrypt(
+        JSON.stringify(json),
+        process.env.INVITE_SECRET_KEY as string,
+      ).toString();
+      const newInvite: InviteType = {
+        key: ciphertext,
+        expire: new Date().getTime() + 3600,
+      };
+      const newInviteDoc: InviteDocument = new Invite(newInvite);
+      await newInviteDoc.save();
 
-    const body = {
-      to: [email],
-      ...inviteMemberTemplate(project, encodeURIComponent(ciphertext)),
-    };
+      const body = {
+        to: [email],
+        ...inviteMemberTemplate(project, encodeURIComponent(ciphertext)),
+      };
 
-    const res = await sendMail(body);
-    info.push(res);
-  });
+      const res = await sendMail(body);
+      info.push(res);
+    });
 
-  ctx.body = info;
-  await next();
+    ctx.body = info;
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/project/controllers/updateProjectName.ts
+++ b/src/routes/project/controllers/updateProjectName.ts
@@ -14,8 +14,8 @@ export default async (ctx: Context): Promise<void> => {
   const { name }: IBody = ctx.request.body;
   try {
     await Project.update({ _id: projectId }, { name });
+    ctx.status = 200;
   } catch (e) {
-    ctx.throw(400, 'internal server error');
+    ctx.throw(400);
   }
-  ctx.status = 200;
 };

--- a/src/routes/project/controllers/updateProjectOwner.ts
+++ b/src/routes/project/controllers/updateProjectOwner.ts
@@ -15,19 +15,18 @@ interface IBody {
 export default async (ctx: Context): Promise<void> => {
   const { id: projectId }: IParams = ctx.params;
   const { originUserId, targetUserId }: IBody = ctx.request.body;
-  if (ctx.state.user._id !== originUserId) {
-    throw Error();
-  }
-
   try {
+    if (ctx.state.user._id !== originUserId) {
+      throw Error();
+    }
     const targetUserCount = await User.countDocuments({ _id: targetUserId });
     const projectOwnerCount = await Project.countDocuments({ _id: projectId, owner: originUserId });
     if (targetUserCount !== 1 || projectOwnerCount !== 1) {
       throw Error();
     }
     await swapOwner({ projectId, originUserId, targetUserId });
+    ctx.status = 200;
   } catch (e) {
-    ctx.throw(400, 'internal server error');
+    ctx.throw(400);
   }
-  ctx.status = 200;
 };

--- a/src/routes/sdk/controllers/addCrime.ts
+++ b/src/routes/sdk/controllers/addCrime.ts
@@ -1,8 +1,8 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import { ICrime } from '../../../models/Crime';
 import addCrime from '../services/addCrime';
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const newCrime: ICrime = ctx.request.body;
   const { projectId } = ctx.params;
   newCrime.projectId = projectId;
@@ -11,8 +11,6 @@ export default async (ctx: Context, next: Next): Promise<void> => {
     await addCrime(newCrime, projectId);
     ctx.response.status = 200;
   } catch (e) {
-    ctx.throw(400, 'validation failed');
+    ctx.throw(400);
   }
-
-  await next();
 };

--- a/src/routes/sdk/controllers/addCrimes.ts
+++ b/src/routes/sdk/controllers/addCrimes.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-param-reassign */
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import { ICrime } from '../../../models/Crime';
 import addCrime from '../services/addCrime';
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const newCrimes: ICrime[] = ctx.request.body;
   const { projectId } = ctx.params;
   const userIp = ctx.request.ip;
@@ -19,8 +19,6 @@ export default async (ctx: Context, next: Next): Promise<void> => {
     );
     ctx.response.status = 200;
   } catch (e) {
-    ctx.throw(400, 'validation failed');
+    ctx.throw(400);
   }
-
-  await next();
 };

--- a/src/routes/sdk/controllers/addSession.ts
+++ b/src/routes/sdk/controllers/addSession.ts
@@ -1,13 +1,12 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 
 import Project, { IProjectDocument } from '../../../models/Project';
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
+  const params = ctx.request.body;
+  const { projectId } = ctx.params;
+  params.ip = ctx.request.ip;
   try {
-    const params = ctx.request.body;
-    const { projectId } = ctx.params;
-
-    params.ip = ctx.request.ip;
     const project = (await Project.findById(projectId)) as IProjectDocument;
 
     project.addSession(params);
@@ -15,8 +14,6 @@ export default async (ctx: Context, next: Next): Promise<void> => {
 
     ctx.response.status = 200;
   } catch (e) {
-    ctx.throw(400, 'validation failed');
+    ctx.throw(400);
   }
-
-  await next();
 };

--- a/src/routes/sdk/controllers/addVisits.ts
+++ b/src/routes/sdk/controllers/addVisits.ts
@@ -20,6 +20,6 @@ export default async (ctx: Context): Promise<void> => {
     await newVisitsDoc.save();
     ctx.response.status = 200;
   } catch (e) {
-    ctx.throw(400, 'internal error');
+    ctx.throw(400);
   }
 };

--- a/src/routes/stats/controllers/getSession.ts
+++ b/src/routes/stats/controllers/getSession.ts
@@ -112,6 +112,6 @@ export default async (ctx: Context): Promise<void> => {
     ]);
     ctx.body = { move, duration, perTime, perDay, perMonth };
   } catch (e) {
-    ctx.throw(500);
+    ctx.throw(400);
   }
 };

--- a/src/routes/stats/controllers/getShares.ts
+++ b/src/routes/stats/controllers/getShares.ts
@@ -45,11 +45,11 @@ export default async (ctx: Context, next: Next): Promise<void> => {
 
   const issueAggregate = getIssueSharesAggregate(projectObjectIds, start, end, filterAggregate);
   const metaAggregate = getSharesAggregate(projectIds, start, end);
-
-  const issue = await Issue.aggregate(issueAggregate);
-  const [metas] = await Crime.aggregate([...filterAggregate, ...metaAggregate]);
-
-  ctx.body = { issue, ...metas };
-
-  await next();
+  try {
+    const issue = await Issue.aggregate(issueAggregate);
+    const [metas] = await Crime.aggregate([...filterAggregate, ...metaAggregate]);
+    ctx.body = { issue, ...metas };
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/stats/controllers/getShares.ts
+++ b/src/routes/stats/controllers/getShares.ts
@@ -1,4 +1,4 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import { Types } from 'mongoose';
 
 import Issue from '../../../models/Issue';
@@ -18,7 +18,7 @@ interface StatQuery {
   end?: string;
 }
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const params: StatQuery = ctx.query;
   const { projectId, browser, os, url } = params;
 

--- a/src/routes/stats/controllers/getSharesByIssue.ts
+++ b/src/routes/stats/controllers/getSharesByIssue.ts
@@ -59,6 +59,6 @@ export default async (ctx: Context): Promise<void> => {
     ]);
     ctx.body = result;
   } catch (e) {
-    ctx.throw(500);
+    ctx.throw(400);
   }
 };

--- a/src/routes/stats/controllers/getStats.ts
+++ b/src/routes/stats/controllers/getStats.ts
@@ -1,4 +1,4 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import Issue, { IIssueDocument } from '../../../models/Issue';
 import { getPeriodByMillisec, getDefaultInterval, getStatsAggregate } from '../services/statUtil';
 
@@ -10,15 +10,16 @@ interface StatQuery {
   end?: string;
 }
 
-export default async (ctx: Context, next: Next): Promise<void> => {
+export default async (ctx: Context): Promise<void> => {
   const params: StatQuery = ctx.query;
   const period: number = getPeriodByMillisec(params.period);
   const interval: number = getDefaultInterval(params.period, params.interval);
   const start: Date = params.start ? new Date(params.start) : new Date(Date.now() - period); // 현재 - 구할 시간
   const end: Date = params.end ? new Date(params.end) : new Date();
-
-  const result: IIssueDocument[] = await Issue.aggregate(getStatsAggregate(interval, start, end));
-  ctx.body = result;
-
-  await next();
+  try {
+    const result: IIssueDocument[] = await Issue.aggregate(getStatsAggregate(interval, start, end));
+    ctx.body = result;
+  } catch (e) {
+    ctx.throw(400);
+  }
 };

--- a/src/routes/stats/services/statUtil.ts
+++ b/src/routes/stats/services/statUtil.ts
@@ -67,10 +67,7 @@ const addFilter = (field: string, value: string | string[] | undefined, aggregat
 
 const getStatsAggregate = (interval: number, start: Date, end: Date): Record<string, unknown>[] => {
   return [
-    // 1. 지금 시간부터 period를 뺀 시간까지의 데이터의 occuredAt을 추출한다.
     { $match: { occuredAt: { $gte: start, $lte: end } } },
-    // 2. (occuredAt - 시간 기본값) - ((occuredAt - 시간 기본값) % interval)으로 시간을 나누어 그룹핑해주고, 그룹마다 count에 1을 더해준다.
-    // mod기 때문에 나머지 초가 없어진다.
     {
       $group: {
         _id: {
@@ -84,8 +81,6 @@ const getStatsAggregate = (interval: number, start: Date, end: Date): Record<str
         },
       },
     },
-    // 3. _id에 저장되어있던 occuredAt의 시간을 date 객체 형태로 추출해준다.
-    // 기존의 id를 제거하기 위해 _id:0을 해준다. (원리는 모르겠음)
     {
       $project: {
         occuredAt: { $convert: { input: '$_id', to: 'date' } },
@@ -93,7 +88,6 @@ const getStatsAggregate = (interval: number, start: Date, end: Date): Record<str
         _id: 0,
       },
     },
-    // 4. 오름차순으로 정렬해준다.
     {
       $sort: {
         occuredAt: 1,

--- a/src/routes/user/controllers/getUser.ts
+++ b/src/routes/user/controllers/getUser.ts
@@ -1,4 +1,4 @@
-import { Context, Next } from 'koa';
+import { Context } from 'koa';
 import User from '../../../models/User';
 
 interface IParams {

--- a/src/routes/user/controllers/getUser.ts
+++ b/src/routes/user/controllers/getUser.ts
@@ -12,6 +12,6 @@ export default async (ctx: Context): Promise<void> => {
     if (result === null) throw Error();
     ctx.body = result;
   } catch (e) {
-    ctx.throw(500);
+    ctx.throw(400);
   }
 };

--- a/src/routes/visits/controllers/getVisits.ts
+++ b/src/routes/visits/controllers/getVisits.ts
@@ -9,26 +9,30 @@ import {
 
 export default async (ctx: Context): Promise<void> => {
   const { projectId, type, year, month } = ctx.query;
-  if (type === 'daily') {
-    const projectIds = convertToArray(projectId);
-    const filledDatas = await Promise.all(
-      projectIds.map(async (targetProjectId) => {
-        const visitsByDate = await getDailyInMonth({ targetProjectId, year, month });
-        const filledData = fillDateCountsWithZero({ visitsByDate, targetProjectId, year, month });
-        return filledData;
-      }),
-    );
-    ctx.response.body = filledDatas;
-  }
-  if (type === 'monthly') {
-    const projectIds = convertToArray(projectId);
-    const filledDatas = await Promise.all(
-      projectIds.map(async (targetProjectId) => {
-        const visitsByMonth = await getMonthlyInYear({ targetProjectId, year });
-        const filledData = fillMonthCountsWithZero({ visitsByMonth, targetProjectId, year });
-        return filledData;
-      }),
-    );
-    ctx.response.body = filledDatas;
+  try {
+    if (type === 'daily') {
+      const projectIds = convertToArray(projectId);
+      const filledDatas = await Promise.all(
+        projectIds.map(async (targetProjectId) => {
+          const visitsByDate = await getDailyInMonth({ targetProjectId, year, month });
+          const filledData = fillDateCountsWithZero({ visitsByDate, targetProjectId, year, month });
+          return filledData;
+        }),
+      );
+      ctx.response.body = filledDatas;
+    }
+    if (type === 'monthly') {
+      const projectIds = convertToArray(projectId);
+      const filledDatas = await Promise.all(
+        projectIds.map(async (targetProjectId) => {
+          const visitsByMonth = await getMonthlyInYear({ targetProjectId, year });
+          const filledData = fillMonthCountsWithZero({ visitsByMonth, targetProjectId, year });
+          return filledData;
+        }),
+      );
+      ctx.response.body = filledDatas;
+    }
+  } catch (e) {
+    ctx.throw(400);
   }
 };

--- a/src/utils/authMiddleware.ts
+++ b/src/utils/authMiddleware.ts
@@ -2,11 +2,7 @@ import { Context, Next } from 'koa';
 import checkToken from './checkToken';
 
 const authMiddleware = async (ctx: Context, next: Next): Promise<void> => {
-  /**
-   * @TODO
-   * whitelist에서 crime url 삭제
-   */
-  const whiteUrls = ['/api/crime', '/api/sdk'];
+  const whiteUrls = ['/api/sdk'];
   if (
     /\/api\/auth\/github/g.test(ctx.url) ||
     whiteUrls.some((url) => ctx.originalUrl.includes(url))
@@ -20,7 +16,7 @@ const authMiddleware = async (ctx: Context, next: Next): Promise<void> => {
     const userId: string = checkToken(jwtToken);
     ctx.state.user = { _id: userId };
   } catch (e) {
-    ctx.throw(401, 'Invalid Token');
+    ctx.throw(401);
   }
   await next();
 };


### PR DESCRIPTION
### 구현의도
- project / user 삭제 api 수정
  project에서 user가 삭제되면 user의 projects에서 projectid가 삭제되는 기능 추가
  project가 삭제 될 때 soft delete이므로 기능 구현 하지 않음

- controller 에러 리팩토링
  불필요한 import문 삭제, error 통일

- error handler router 구현

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- project가 삭제 될 때 soft delete이므로 기능 구현 하지 않았습니다.
   user의 projects를 가져올 때 isDeleted는 이미 구현되어 있었습니다.

