### PR TITLE
Session(Analyze) 시간 수정, 프로젝트 삭제시 Alert 삭제

### DIFF
--- a/src/routes/sdk/controllers/addSession.ts
+++ b/src/routes/sdk/controllers/addSession.ts
@@ -2,7 +2,7 @@ import { Context } from 'koa';
 
 import Project, { IProjectDocument } from '../../../models/Project';
 
-const NINE_HOUR = 9 * 60 * 60 * 1000;
+const TIMEZONE_OFFSET = 9 * 60 * 60 * 1000;
 
 export default async (ctx: Context): Promise<void> => {
   const params = ctx.request.body;
@@ -10,8 +10,8 @@ export default async (ctx: Context): Promise<void> => {
   params.ip = ctx.request.ip;
   try {
     const project = (await Project.findById(projectId)) as IProjectDocument;
-    params.prevTime += NINE_HOUR;
-    params.presentTime += NINE_HOUR;
+    params.prevTime += TIMEZONE_OFFSET;
+    params.presentTime += TIMEZONE_OFFSET;
     project.addSession(params);
     project.save();
 

--- a/src/routes/sdk/controllers/addSession.ts
+++ b/src/routes/sdk/controllers/addSession.ts
@@ -2,13 +2,16 @@ import { Context } from 'koa';
 
 import Project, { IProjectDocument } from '../../../models/Project';
 
+const NINE_HOUR = 9 * 60 * 60 * 1000;
+
 export default async (ctx: Context): Promise<void> => {
   const params = ctx.request.body;
   const { projectId } = ctx.params;
   params.ip = ctx.request.ip;
   try {
     const project = (await Project.findById(projectId)) as IProjectDocument;
-
+    params.prevTime += NINE_HOUR;
+    params.presentTime += NINE_HOUR;
     project.addSession(params);
     project.save();
 


### PR DESCRIPTION
### 구현의도
- Session(Analyze) 시간 수정
  - mongoDB로 쿼리를 실행하기 때문에 Timezone이 맞지 않는 오류
    aggregate를 사용하여 mongDB쪽의 timezone을 변경해야하지만 방법이 없어서 Application 쪽에서 해결
    삽입할 때 9시간을 더해주는 방법으로 오류 수정

- 프로젝트 삭제시 Alert 삭제

### 기능 흐름도, 클래스 다이어그램(선택사항)
- 

### 사용된 기술(선택사항)
- 

### 리뷰 & 논의사항 & 궁금한점(선택사항)
- 
